### PR TITLE
診療科情報取得APIの実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/departments/DepartmentsController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/departments/DepartmentsController.kt
@@ -1,0 +1,31 @@
+package com.unicorn.api.controller.departments
+
+import com.unicorn.api.query_service.departments.DepartmentsDto
+import com.unicorn.api.query_service.departments.DepartmentsQueryService
+import com.unicorn.api.query_service.departments.DepartmentsResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+
+@RestController
+class DepartmentsController(
+    private val departmentsQueryService: DepartmentsQueryService,
+) {
+    @GetMapping("/departments")
+    fun getDepartments(@RequestHeader("X-UID") uid: String): ResponseEntity<DepartmentsResult> {
+        try {
+            val result = departmentsQueryService.get()
+            return ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).build()
+        }
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/departments/DepartmentsQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/departments/DepartmentsQueryService.kt
@@ -1,0 +1,45 @@
+package com.unicorn.api.query_service.departments
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Service
+import java.util.*
+
+interface DepartmentsQueryService {
+    fun get(): DepartmentsResult
+}
+
+@Service
+class DepartmentsQueryServiceImpl(
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) : DepartmentsQueryService {
+    override fun get(): DepartmentsResult {
+        val sql = """
+            SELECT 
+                "departmentID",
+                "departmentName"
+            FROM "Departments";
+        """.trimIndent()
+        val departments = namedParameterJdbcTemplate.query(
+            sql,
+            { rs, _ ->
+                DepartmentsDto(
+                    departmentID = UUID.fromString(rs.getString("departmentID")),
+                    departmentName = rs.getString("departmentName")
+                )
+            }
+        )
+        return DepartmentsResult(departments)
+    }
+}
+
+
+data class DepartmentsDto(
+    val departmentID: UUID,
+    val departmentName: String
+)
+
+data class DepartmentsResult(
+    val data: List<DepartmentsDto>
+)
+

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/departments/DepartmentsQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/departments/DepartmentsQueryService.kt
@@ -16,16 +16,16 @@ class DepartmentsQueryServiceImpl(
     override fun get(): DepartmentsResult {
         val sql = """
             SELECT 
-                "departmentID",
-                "departmentName"
-            FROM "Departments";
+                "department_id",
+                "department_name"
+            FROM departments;
         """.trimIndent()
         val departments = namedParameterJdbcTemplate.query(
             sql,
             { rs, _ ->
                 DepartmentsDto(
-                    departmentID = UUID.fromString(rs.getString("departmentID")),
-                    departmentName = rs.getString("departmentName")
+                    departmentID = UUID.fromString(rs.getString("department_id")),
+                    departmentName = rs.getString("department_name")
                 )
             }
         )

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DepartmentsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DepartmentsGetTest.kt
@@ -1,0 +1,59 @@
+package com.unicorn.api.controller.departments
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.test.context.jdbc.Sql
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/department/Insert_Department_Data.sql")
+class DepartmentsGetTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 200 when departments is called`(){
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("/departments").headers(HttpHeaders().apply {
+            add("X-UID", "a1dcb69e-472f-4a57-90a2-f2c63b62ec90")
+        }))
+        result.andExpect(status().isOk)
+        result.andExpect(content().json("""
+            {
+                "data": [
+                    {
+                        departmentID: "a1dcb69e-472f-4a57-90a2-f2c63b62ec90",
+                        departmentName: "総合内科"
+                    },
+                    {   
+                        departmentID: "b68a87a3-b7f1-4b85-b0ab-6c620d68d791",
+                        departmentName: "循環器内科"
+                    },
+                    {   
+                        departmentID: "cd273b1b-0c3b-4b89-b2b9-01b21832b44c",
+                        departmentName: "呼吸器内科"
+                    },
+                    {   
+                        departmentID: "df3f2f1d-0c32-44d9-a429-5260e62e81aa",
+                        departmentName: "消化器内科"
+                    },
+                    {   
+                        departmentID: "ed8fb319-798f-4b47-bcf3-2a8f6486e38d",
+                        departmentName: "腎臓・内分泌内科"
+                    }
+                ]
+            }
+        """.trimIndent(), true))
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DepartmentsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DepartmentsGetTest.kt
@@ -5,7 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
-import org.springframework.test.context.ActiveProfiles
+// import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -13,7 +14,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.test.context.jdbc.Sql
 
-@ActiveProfiles("test")
+// @ActiveProfiles("test")
+@TestPropertySource(locations=["classpath:application-test.properties"])
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DepartmentsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DepartmentsGetTest.kt
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
-// import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -14,7 +13,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.test.context.jdbc.Sql
 
-// @ActiveProfiles("test")
 @TestPropertySource(locations=["classpath:application-test.properties"])
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/api-server/src/test/resources/db/department/Insert_Department_Data.sql
+++ b/api-server/src/test/resources/db/department/Insert_Department_Data.sql
@@ -1,0 +1,7 @@
+INSERT INTO Departments (departmentID, departmentName)
+VALUES
+('a1dcb69e-472f-4a57-90a2-f2c63b62ec90', '総合内科'),
+('b68a87a3-b7f1-4b85-b0ab-6c620d68d791', '循環器内科'),
+('cd273b1b-0c3b-4b89-b2b9-01b21832b44c', '呼吸器内科'),
+('df3f2f1d-0c32-44d9-a429-5260e62e81aa', '消化器内科'),
+('ed8fb319-798f-4b47-bcf3-2a8f6486e38d', '腎臓・内分泌内科');

--- a/api-server/src/test/resources/db/department/Insert_Department_Data.sql
+++ b/api-server/src/test/resources/db/department/Insert_Department_Data.sql
@@ -1,4 +1,4 @@
-INSERT INTO Departments (departmentID, departmentName)
+INSERT INTO "Departments" ("departmentID", "departmentName")
 VALUES
 ('a1dcb69e-472f-4a57-90a2-f2c63b62ec90', '総合内科'),
 ('b68a87a3-b7f1-4b85-b0ab-6c620d68d791', '循環器内科'),

--- a/api-server/src/test/resources/db/department/Insert_Department_Data.sql
+++ b/api-server/src/test/resources/db/department/Insert_Department_Data.sql
@@ -1,4 +1,4 @@
-INSERT INTO "Departments" ("departmentID", "departmentName")
+INSERT INTO departments ("department_id", "department_name")
 VALUES
 ('a1dcb69e-472f-4a57-90a2-f2c63b62ec90', '総合内科'),
 ('b68a87a3-b7f1-4b85-b0ab-6c620d68d791', '循環器内科'),


### PR DESCRIPTION
## 概要
診療科情報を一括取得するAPIを実装する

## 変更点
- api-server/src/main/kotlin/com/unicorn/api/controller配下にコントローラー作成
　departments/DepartmentsController.ktを作成

- api-server/src/main/kotlin/com/unicorn/api/query_service配下にクエリサービス作成
　departments/DepartmentsQueryService.ktを作成

- api-server/src/test/kotlin/com/unicorn/api/controller配下にテストコントローラー作成
　departments/DepartmentsGetTest.ktを作成

- api-server/src/test/resources/db配下にテスト用データ挿入SQL作成
　department/Insert_Department_Data.sqlを作成

## 確認したこと
test成功
build成功
bootRun成功
Postmanで/departmentsにGETリクエスト成功

## リリース時に確認すること
/departmentsにGETリクエストした時、診療科情報を一括取得できるか
