### PR TITLE
[TSK-189] medicine API おくすり一覧取得機能の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -1,10 +1,7 @@
 package com.unicorn.api.controller.medicine
 
-import com.unicorn.api.controller.api_response.ResponseError
-import com.unicorn.api.controller.user.UserPostRequest
-import com.unicorn.api.domain.account.UID
+
 import com.unicorn.api.query_service.medicine.MedicineQueryService
-import com.unicorn.api.query_service.medicine.MedicineResult
 import com.unicorn.api.query_service.user.UserQueryService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -19,12 +16,12 @@ class MedicineController(
         return try {
             val user = userQueryService.getOrNullBy(uid)
 
-            if (user != null) {
-                val result = medicineQueryService.getMedicines(uid)
-                ResponseEntity.ok(result)
-            } else {
-                ResponseEntity.status(400).body("User not found")
+            if (user == null) {
+                return ResponseEntity.status(400).body("User not found")
             }
+
+            val result = medicineQueryService.getMedicines(uid)
+            ResponseEntity.ok(result)
         } catch (e: Exception) {
             ResponseEntity.status(500).body("Internal Server Error")
         }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -1,12 +1,13 @@
 package com.unicorn.api.controller.medicine
 
+import com.unicorn.api.controller.api_response.ResponseError
+import com.unicorn.api.controller.user.UserPostRequest
+import com.unicorn.api.domain.account.UID
 import com.unicorn.api.query_service.medicine.MedicineQueryService
 import com.unicorn.api.query_service.medicine.MedicineResult
 import com.unicorn.api.query_service.user.UserQueryService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class MedicineController(
@@ -22,7 +23,7 @@ class MedicineController(
                 val result = medicineQueryService.getMedicines(uid)
                 ResponseEntity.ok(result)
             } else {
-                ResponseEntity.status(404).body("User not found")
+                ResponseEntity.status(400).body("User not found")
             }
         } catch (e: Exception) {
             ResponseEntity.status(500).body("Internal Server Error")

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -1,0 +1,23 @@
+package com.unicorn.api.controller.medicine
+
+import com.unicorn.api.query_service.medicine.MedicineQueryService
+import com.unicorn.api.query_service.medicine.MedicineResult
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MedicineController(
+    private val medicineQueryService: MedicineQueryService
+) {
+    @GetMapping("/medicines")
+    fun getMedicines(@RequestHeader("X-UID") uid: String): ResponseEntity<MedicineResult> {
+        return try {
+            val result = medicineQueryService.getMedicines()
+            ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            ResponseEntity.status(500).build()
+        }
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.controller.medicine
 
 import com.unicorn.api.query_service.medicine.MedicineQueryService
 import com.unicorn.api.query_service.medicine.MedicineResult
+import com.unicorn.api.query_service.user.UserQueryService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
@@ -9,15 +10,22 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class MedicineController(
-    private val medicineQueryService: MedicineQueryService
+    private val medicineQueryService: MedicineQueryService,
+    private val userQueryService: UserQueryService
 ) {
     @GetMapping("/medicines")
-    fun getMedicines(@RequestHeader("X-UID") uid: String): ResponseEntity<MedicineResult> {
+    fun getMedicines(@RequestHeader("X-UID") uid: String): ResponseEntity<*> {
         return try {
-            val result = medicineQueryService.getMedicines()
-            ResponseEntity.ok(result)
+            val user = userQueryService.getOrNullBy(uid)
+
+            if (user != null) {
+                val result = medicineQueryService.getMedicines(uid)
+                ResponseEntity.ok(result)
+            } else {
+                ResponseEntity.status(404).body("User not found")
+            }
         } catch (e: Exception) {
-            ResponseEntity.status(500).build()
+            ResponseEntity.status(500).body("Internal Server Error")
         }
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
@@ -1,12 +1,13 @@
 package com.unicorn.api.query_service.medicine
 
 import com.unicorn.api.application.hospital.HospitalDto
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
 import java.util.*
 
 interface MedicineQueryService {
-    fun getMedicines(): MedicineResult
+    fun getMedicines(uid: String): MedicineResult
 }
 
 @Service
@@ -14,7 +15,7 @@ class MedicineQueryServiceImpl(
     private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
 ) : MedicineQueryService {
 
-    override fun getMedicines(): MedicineResult {
+    override fun getMedicines(uid: String): MedicineResult {
         val sql = """
             SELECT
                 medicine_id,
@@ -22,11 +23,17 @@ class MedicineQueryServiceImpl(
                 count,
                 quantity
             FROM medicines
-            WHERE deleted_at IS NULL
+            WHERE 
+                user_id = :userID
+            AND deleted_at IS NULL
         """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource()
+            .addValue("userID", uid)
 
         val medicines = namedParameterJdbcTemplate.query(
             sql,
+            sqlParams,
             { rs, _ ->
                 MedicineDto(
                     medicineID = rs.getObject("medicine_id", UUID::class.java),

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
@@ -16,6 +16,7 @@ class MedicineQueryServiceImpl(
 ) : MedicineQueryService {
 
     override fun getMedicines(uid: String): MedicineResult {
+        // language=postgresql
         val sql = """
             SELECT
                 medicine_id,

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
@@ -1,0 +1,53 @@
+package com.unicorn.api.query_service.medicine
+
+import com.unicorn.api.application.hospital.HospitalDto
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Service
+import java.util.*
+
+interface MedicineQueryService {
+    fun getMedicines(): MedicineResult
+}
+
+@Service
+class MedicineQueryServiceImpl(
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) : MedicineQueryService {
+
+    override fun getMedicines(): MedicineResult {
+        val sql = """
+            SELECT
+                medicine_id,
+                medicine_name,
+                count,
+                quantity
+            FROM medicines
+            WHERE deleted_at IS NULL
+        """.trimIndent()
+
+        val medicines = namedParameterJdbcTemplate.query(
+            sql,
+            { rs, _ ->
+                MedicineDto(
+                    medicineID = rs.getObject("medicine_id", UUID::class.java),
+                    medicineName = rs.getString("medicine_name"),
+                    count = rs.getInt("count"),
+                    quantity = rs.getInt("quantity")
+                )
+            }
+        )
+
+        return MedicineResult(medicines)
+    }
+}
+
+data class MedicineResult(
+    val data: List<MedicineDto>
+)
+
+data class MedicineDto(
+    val medicineID: UUID,
+    val medicineName: String,
+    val count: Int,
+    val quantity: Int
+)

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinesGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinesGetTest.kt
@@ -1,0 +1,67 @@
+package com.unicorn.api.controller.medicine
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/medicine/Insert_Medicine_Data.sql")
+class MedicinesGetTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 200 with correct medicine data`() {
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("/medicines").headers(HttpHeaders().apply {
+            add("X-UID", "test-uid")
+        }))
+
+        result.andExpect(status().isOk)
+        result.andExpect(
+            content().json("""
+            {
+                "data": [
+                    {
+                        "medicineID": "123e4567-e89b-12d3-a456-426614174000",
+                        "medicineName": "Paracetamol",
+                        "count": 5,
+                        "quantity": 10
+                    },
+                    {
+                        "medicineID": "123e4567-e89b-12d3-a456-426614174001",
+                        "medicineName": "Ibuprofen",
+                        "count": 3,
+                        "quantity": 15
+                    },
+                    {
+                        "medicineID": "123e4567-e89b-12d3-a456-426614174002",
+                        "medicineName": "Aspirin",
+                        "count": 8,
+                        "quantity": 20
+                    },
+                    {
+                        "medicineID": "123e4567-e89b-12d3-a456-426614174003",
+                        "medicineName": "Amoxicillin",
+                        "count": 2,
+                        "quantity": 5
+                    }
+                ]
+            }
+        """.trimIndent(), true))
+    }
+
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinesGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinesGetTest.kt
@@ -27,7 +27,7 @@ class MedicinesGetTest {
     @Test
     fun `should return 200 with correct medicine data`() {
         val result = mockMvc.perform(MockMvcRequestBuilders.get("/medicines").headers(HttpHeaders().apply {
-            add("X-UID", "test-uid")
+            add("X-UID", "test")
         }))
 
         result.andExpect(status().isOk)

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinesGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinesGetTest.kt
@@ -64,4 +64,13 @@ class MedicinesGetTest {
         """.trimIndent(), true))
     }
 
+    @Test
+    fun `should return 400 when uid is invalid`() {
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("/medicines").headers(HttpHeaders().apply {
+            add("X-UID", "invalid-uid")
+        }))
+
+        result.andExpect(status().isBadRequest)
+        result.andExpect(content().string("User not found"))
+    }
 }


### PR DESCRIPTION
## 概要
おくすり一覧取得機能の実装

## 変更点

- /medicine にコントローラ層とクエリサービス層を実装。
- コントローラの単体テストを記述。

## 確認したこと
- テストが通ること。