### PR TITLE
[TSK-185] family_emailのGET実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -1,0 +1,28 @@
+package com.unicorn.api.controller.family_email
+
+import com.unicorn.api.query_service.family_email.*
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+class FamilyEmailController(
+    private val familyEmailQueryService: FamilyEmailQueryService,
+) {
+    @GetMapping("/family_emails")
+    fun getFamilyEmails(@RequestHeader("X-UID") uid: String): ResponseEntity<FamilyEmailResult> {
+        try{
+            val result = familyEmailQueryService.get(uid)
+            return ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).build()
+        }
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -18,7 +18,7 @@ class FamilyEmailController(
     fun get(@RequestHeader("X-UID") uid: String): ResponseEntity<*> {
         try{
             userQueryService.getOrNullBy(uid)
-                ?: return ResponseEntity.status(404).body(ResponseError("User not found"))
+                ?: return ResponseEntity.status(400).body(ResponseError("User not found"))
 
             val result = familyEmailQueryService.get(UserID(uid))
             return ResponseEntity.ok(result)

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -1,28 +1,29 @@
 package com.unicorn.api.controller.family_email
 
-import com.unicorn.api.query_service.family_email.*
+import com.unicorn.api.controller.api_response.ResponseError
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.query_service.user.UserQueryService
+import com.unicorn.api.query_service.family_email.FamilyEmailQueryService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.*
 
-@RestController
+
+@Controller
 class FamilyEmailController(
+    private val userQueryService: UserQueryService,
     private val familyEmailQueryService: FamilyEmailQueryService,
 ) {
     @GetMapping("/family_emails")
-    fun getFamilyEmails(@RequestHeader("X-UID") uid: String): ResponseEntity<FamilyEmailResult> {
+    fun get(@RequestHeader("X-UID") uid: String): ResponseEntity<*> {
         try{
-            val result = familyEmailQueryService.get(uid)
+            userQueryService.getOrNullBy(uid)
+                ?: return ResponseEntity.status(404).body(ResponseError("User not found"))
+
+            val result = familyEmailQueryService.get(UserID(uid))
             return ResponseEntity.ok(result)
         } catch (e: Exception) {
-            return ResponseEntity.status(500).build()
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/family_email/FamilyEmailQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/family_email/FamilyEmailQueryService.kt
@@ -1,19 +1,20 @@
 package com.unicorn.api.query_service.family_email
 
+import com.unicorn.api.domain.user.UserID
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Service
 import java.util.*
 
 interface FamilyEmailQueryService {
-    fun get(uid: String): FamilyEmailResult
+    fun get(userID: UserID): FamilyEmailResult
 }
 
 @Service
 class FamilyEmailQueryServiceImpl(
     private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
 ) : FamilyEmailQueryService {
-    override fun get(uid: String): FamilyEmailResult {
+    override fun get(userID: UserID): FamilyEmailResult {
         //language=postgresql
         val sql = """
             SELECT
@@ -27,7 +28,7 @@ class FamilyEmailQueryServiceImpl(
             WHERE user_id = :userID 
             AND deleted_at IS NULL
         """.trimIndent()
-        val sqlParams = MapSqlParameterSource().addValue("userID", uid)
+        val sqlParams = MapSqlParameterSource().addValue("userID", userID.value)
         val familyEmails = namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
             FamilyEmailDto(
                 familyEmailID = UUID.fromString(rs.getString("family_email_id")),

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/family_email/FamilyEmailQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/family_email/FamilyEmailQueryService.kt
@@ -1,0 +1,55 @@
+package com.unicorn.api.query_service.family_email
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Service
+import java.util.*
+
+interface FamilyEmailQueryService {
+    fun get(uid: String): FamilyEmailResult
+}
+
+@Service
+class FamilyEmailQueryServiceImpl(
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) : FamilyEmailQueryService {
+    override fun get(uid: String): FamilyEmailResult {
+        //language=postgresql
+        val sql = """
+            SELECT
+                family_email_id,
+                email,
+                family_first_name,
+                family_last_name,
+                phone_number,
+                icon_image_url
+            FROM family_emails
+            WHERE user_id = :userID 
+            AND deleted_at IS NULL
+        """.trimIndent()
+        val sqlParams = MapSqlParameterSource().addValue("userID", uid)
+        val familyEmails = namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
+            FamilyEmailDto(
+                familyEmailID = UUID.fromString(rs.getString("family_email_id")),
+                email = rs.getString("email"),
+                familyFirstName = rs.getString("family_first_name"),
+                familyLastName = rs.getString("family_last_name"),
+                phoneNumber = rs.getString("phone_number"),
+                iconImageUrl = rs.getString("icon_image_url")
+            )
+        }
+        return FamilyEmailResult(familyEmails)
+    }   
+}
+
+data class FamilyEmailDto(
+    val familyEmailID: UUID,
+    val email: String,
+    val familyFirstName: String,
+    val familyLastName: String,
+    val phoneNumber: String,
+    val iconImageUrl: String?
+)
+data class FamilyEmailResult(
+    val data: List<FamilyEmailDto>
+)

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/family_email/FamilyEmailQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/family_email/FamilyEmailQueryService.kt
@@ -33,8 +33,8 @@ class FamilyEmailQueryServiceImpl(
             FamilyEmailDto(
                 familyEmailID = UUID.fromString(rs.getString("family_email_id")),
                 email = rs.getString("email"),
-                familyFirstName = rs.getString("family_first_name"),
-                familyLastName = rs.getString("family_last_name"),
+                firstName = rs.getString("family_first_name"),
+                lastName = rs.getString("family_last_name"),
                 phoneNumber = rs.getString("phone_number"),
                 iconImageUrl = rs.getString("icon_image_url")
             )
@@ -46,8 +46,8 @@ class FamilyEmailQueryServiceImpl(
 data class FamilyEmailDto(
     val familyEmailID: UUID,
     val email: String,
-    val familyFirstName: String,
-    val familyLastName: String,
+    val firstName: String,
+    val lastName: String,
     val phoneNumber: String,
     val iconImageUrl: String?
 )

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
@@ -1,0 +1,51 @@
+package com.unicorn.api.controller.family_email
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.test.context.jdbc.Sql
+
+@TestPropertySource(locations=["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/family_email/Insert_FamilyEmail_Data.sql")
+class FamilyEmailsGetTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 200 when familyEmails is called`(){
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("/family_emails").headers(HttpHeaders().apply {
+            add("X-UID", "test")
+        }))
+        result.andExpect(status().isOk)
+        result.andExpect(content().json(
+            // language=json
+            """
+            {
+                "data": [
+                    {
+                        "familyEmailID": "f47ac10b-58cc-4372-a567-0e02b2c3d470",
+                        "email": "sample@sample.com",
+                        "familyFirstName": "太郎",
+                        "familyLastName": "山田",
+                        "phoneNumber": "09012345678",
+                        "iconImageUrl": "https://example.com"
+                    }
+                ]
+            }
+            """.trimIndent(), true))
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
@@ -39,8 +39,8 @@ class FamilyEmailsGetTest {
                     {
                         "familyEmailID": "f47ac10b-58cc-4372-a567-0e02b2c3d470",
                         "email": "sample@sample.com",
-                        "familyFirstName": "太郎",
-                        "familyLastName": "山田",
+                        "firstName": "太郎",
+                        "lastName": "山田",
                         "phoneNumber": "09012345678",
                         "iconImageUrl": "https://example.com"
                     }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
@@ -48,4 +48,19 @@ class FamilyEmailsGetTest {
             }
             """.trimIndent(), true))
     }
+
+    @Test
+    fun `should return 404 when user is not found`() {
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("/family_emails").headers(HttpHeaders().apply {
+            add("X-UID", "notFound")
+        }))
+        result.andExpect(status().isNotFound)
+        result.andExpect(content().json(
+            // language=json
+            """
+            {
+                "errorType": "User not found"
+            }
+            """.trimIndent(), true))
+    }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailsGetTest.kt
@@ -50,11 +50,11 @@ class FamilyEmailsGetTest {
     }
 
     @Test
-    fun `should return 404 when user is not found`() {
+    fun `should return 400 when user is not found`() {
         val result = mockMvc.perform(MockMvcRequestBuilders.get("/family_emails").headers(HttpHeaders().apply {
             add("X-UID", "notFound")
         }))
-        result.andExpect(status().isNotFound)
+        result.andExpect(status().isBadRequest)
         result.andExpect(content().json(
             // language=json
             """


### PR DESCRIPTION
## 概要
- 家族メールアドレスを一覧取得するAPIを実装する
- 家族メールアドレスが適切に取得できているかどうかを確認するテストを行う

## 変更点
- contorollerのFamilyEmailController.ktを追加
- query_serviceのFamilyEmailQueryService.ktを追加
- GETのテストを行うFamilyEmailGetTest.ktを追加

## 確認したこと
- テストが通ることを確認
- ローカル環境で一覧取得できたことを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
