### PR TITLE
[TSK-186] family_emailのPOST実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/SaveFamilyEmailService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/SaveFamilyEmailService.kt
@@ -23,7 +23,7 @@ class SaveFamilyEmailServiceImpl(
         requireNotNull(user) { "User not found" }
 
         val familyEmail = FamilyEmail.create(
-            familyEmailID = UUID.randomUUID(),
+            userID = userID.value,
             email = familyEmailPostRequest.email,
             firstName = familyEmailPostRequest.firstName,
             lastName = familyEmailPostRequest.lastName,
@@ -31,7 +31,7 @@ class SaveFamilyEmailServiceImpl(
             iconImageUrl = familyEmailPostRequest.iconImageUrl
         )
 
-        familyEmailRepository.store(familyEmail, userID)
+        familyEmailRepository.store(familyEmail)
 
         return familyEmail
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/SaveFamilyEmailService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/SaveFamilyEmailService.kt
@@ -1,0 +1,38 @@
+package com.unicorn.api.application_service.family_email
+
+import com.unicorn.api.controller.family_email.FamilyEmailPostRequest
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.domain.family_email.FamilyEmail
+import com.unicorn.api.infrastructure.user.UserRepository
+import com.unicorn.api.infrastructure.family_email.FamilyEmailRepository
+import java.util.*
+import org.springframework.stereotype.Service
+
+interface SaveFamilyEmailService {
+    fun save(userID: UserID, familyEmailPostRequest: FamilyEmailPostRequest): FamilyEmail
+}
+
+@Service
+class SaveFamilyEmailServiceImpl(
+    private val userRepository: UserRepository,
+    private val familyEmailRepository: FamilyEmailRepository
+) : SaveFamilyEmailService {
+
+    override fun save(userID: UserID, familyEmailPostRequest: FamilyEmailPostRequest): FamilyEmail {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        val familyEmail = FamilyEmail.create(
+            familyEmailID = UUID.randomUUID(),
+            email = familyEmailPostRequest.email,
+            firstName = familyEmailPostRequest.firstName,
+            lastName = familyEmailPostRequest.lastName,
+            phoneNumber = familyEmailPostRequest.phoneNumber,
+            iconImageUrl = familyEmailPostRequest.iconImageUrl
+        )
+
+        familyEmailRepository.store(familyEmail, userID)
+
+        return familyEmail
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -4,6 +4,7 @@ import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.user.UserQueryService
 import com.unicorn.api.query_service.family_email.FamilyEmailQueryService
+import com.unicorn.api.application_service.family_email.SaveFamilyEmailService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*
 class FamilyEmailController(
     private val userQueryService: UserQueryService,
     private val familyEmailQueryService: FamilyEmailQueryService,
+    private val saveFamilyEmailService: SaveFamilyEmailService
 ) {
     @GetMapping("/family_emails")
     fun get(@RequestHeader("X-UID") uid: String): ResponseEntity<*> {
@@ -26,4 +28,27 @@ class FamilyEmailController(
             return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
+
+    @PostMapping("/family_emails")
+    fun post(@RequestHeader("X-UID") uid: String, @RequestBody familyEmailPostRequest: FamilyEmailPostRequest): ResponseEntity<*> {
+        try {
+            userQueryService.getOrNullBy(uid)
+                ?: return ResponseEntity.status(400).body(ResponseError("User not found"))
+
+            val result = saveFamilyEmailService.save(UserID(uid), familyEmailPostRequest)
+            return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
 }
+
+data class FamilyEmailPostRequest(
+    val email: String,
+    val firstName: String,
+    val lastName: String,
+    val phoneNumber: String,
+    val iconImageUrl: String
+)

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -32,9 +32,6 @@ class FamilyEmailController(
     @PostMapping("/family_emails")
     fun post(@RequestHeader("X-UID") uid: String, @RequestBody familyEmailPostRequest: FamilyEmailPostRequest): ResponseEntity<*> {
         try {
-            userQueryService.getOrNullBy(uid)
-                ?: return ResponseEntity.status(400).body(ResponseError("User not found"))
-
             val result = saveFamilyEmailService.save(UserID(uid), familyEmailPostRequest)
             return ResponseEntity.ok(result)
         } catch (e: IllegalArgumentException) {

--- a/api-server/src/main/kotlin/com/unicorn/api/domain/family_email/FamilyEmail.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/domain/family_email/FamilyEmail.kt
@@ -1,10 +1,11 @@
 package com.unicorn.api.domain.family_email
 
-import com.unicorn.api.domain.user.*
+import com.unicorn.api.domain.user.UserID
 import java.util.*
 
 data class FamilyEmail private constructor(
     val familyEmailID: FamilyEmailID,
+    val userID: UserID,
     val email: Email,
     val firstName: FirstName,
     val lastName: LastName,
@@ -14,6 +15,7 @@ data class FamilyEmail private constructor(
     companion object {
         fun fromStore(
             familyEmailID: UUID,
+            userID: String,
             email: String,
             firstName: String,
             lastName: String,
@@ -22,6 +24,7 @@ data class FamilyEmail private constructor(
         ): FamilyEmail {
             return FamilyEmail(
                 familyEmailID = FamilyEmailID(familyEmailID),
+                userID = UserID(userID),
                 email = Email(email),
                 firstName = FirstName(firstName),
                 lastName = LastName(lastName),
@@ -31,7 +34,7 @@ data class FamilyEmail private constructor(
         }
 
         fun create(
-            familyEmailID: UUID,
+            userID: String,
             email: String,
             firstName: String,
             lastName: String,
@@ -39,7 +42,8 @@ data class FamilyEmail private constructor(
             iconImageUrl: String?
         ): FamilyEmail {
             return FamilyEmail(
-                familyEmailID = FamilyEmailID(familyEmailID),
+                familyEmailID = FamilyEmailID(UUID.randomUUID()),
+                userID = UserID(userID),
                 email = Email(email),
                 firstName = FirstName(firstName),
                 lastName = LastName(lastName),

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 import java.util.*
 
 interface FamilyEmailRepository {
-    fun store(familyEmail: FamilyEmail, userID: UserID): FamilyEmail
+    fun store(familyEmail: FamilyEmail): FamilyEmail
     fun getOrNullBy(familyEmailID: FamilyEmailID): FamilyEmail?
     fun delete(familyEmail: FamilyEmail): Unit
 }
@@ -19,7 +19,7 @@ class FamilyEmailRepositoryImpl(
     private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
 ) : FamilyEmailRepository {
 
-    override fun store(familyEmail: FamilyEmail, userID: UserID): FamilyEmail {
+    override fun store(familyEmail: FamilyEmail): FamilyEmail {
         // language=postgresql
         val sql = """
             INSERT INTO family_emails (
@@ -54,7 +54,7 @@ class FamilyEmailRepositoryImpl(
 
         val sqlParams = MapSqlParameterSource()
             .addValue("familyEmailID", familyEmail.familyEmailID.value)
-            .addValue("userID", userID.value)
+            .addValue("userID", familyEmail.userID.value)
             .addValue("email", familyEmail.email.value)
             .addValue("firstName", familyEmail.firstName.value)
             .addValue("lastName", familyEmail.lastName.value)
@@ -89,6 +89,7 @@ class FamilyEmailRepositoryImpl(
         ) { rs, _ ->
             FamilyEmail.fromStore(
                 familyEmailID = UUID.fromString(rs.getString("family_email_id")),
+                userID = rs.getString("user_id"),
                 email = rs.getString("email"),
                 firstName = rs.getString("family_first_name"),
                 lastName = rs.getString("family_last_name"),

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailPostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailPostTest.kt
@@ -1,0 +1,93 @@
+package com.unicorn.api.controller.family_email
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import org.junit.jupiter.api.Assertions.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/user/Insert_Deleted_User_Data.sql")
+@Sql("/db/family_email/Insert_FamilyEmail_Data.sql")
+
+class FamilyEmailPostTest {
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 200 when family email is created`() {
+        val familyEmail = FamilyEmailPostRequest(
+            email = "sample@sample.com",
+            firstName = "test",
+            lastName = "test",
+            phoneNumber = "09012345678",
+            iconImageUrl = "http://example.com/icon.png"
+        )
+
+        val userID = "test"
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/family_emails").headers(HttpHeaders().apply {
+                add("X-UID", userID)
+            })
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(familyEmail))
+        )
+        result.andExpect(status().isOk)
+        val responseContent = result.andReturn().response.contentAsString
+        assertTrue(responseContent.contains(familyEmail.email))
+        assertTrue(responseContent.contains(familyEmail.firstName))
+        assertTrue(responseContent.contains(familyEmail.lastName))
+        assertTrue(responseContent.contains(familyEmail.phoneNumber))
+        assertTrue(responseContent.contains(familyEmail.iconImageUrl))
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val familyEmail = FamilyEmailPostRequest(
+            email = "sample@sample.com",
+            firstName = "test",
+            lastName = "test",
+            phoneNumber = "09012345678",
+            iconImageUrl = "http://example.com/icon.png"
+        )
+        val userID = ""
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/family_emails").headers(HttpHeaders().apply {
+                add("X-UID", userID)
+            })
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(familyEmail))
+        )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(content().json(
+            // language=json
+            """
+            {
+                "errorType": "User not found"
+            }
+            """.trimIndent(), true))
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailPostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailPostTest.kt
@@ -39,8 +39,8 @@ class FamilyEmailPostTest {
     fun `should return 200 when family email is created`() {
         val familyEmail = FamilyEmailPostRequest(
             email = "sample@sample.com",
-            firstName = "test",
-            lastName = "test",
+            firstName = "山田",
+            lastName = "太郎",
             phoneNumber = "09012345678",
             iconImageUrl = "http://example.com/icon.png"
         )
@@ -55,20 +55,25 @@ class FamilyEmailPostTest {
                 .content(objectMapper.writeValueAsString(familyEmail))
         )
         result.andExpect(status().isOk)
-        val responseContent = result.andReturn().response.contentAsString
-        assertTrue(responseContent.contains(familyEmail.email))
-        assertTrue(responseContent.contains(familyEmail.firstName))
-        assertTrue(responseContent.contains(familyEmail.lastName))
-        assertTrue(responseContent.contains(familyEmail.phoneNumber))
-        assertTrue(responseContent.contains(familyEmail.iconImageUrl))
+        result.andExpect(content().json(
+            // language=json
+            """
+            {
+                "email": "${familyEmail.email}",
+                "firstName": "${familyEmail.firstName}",
+                "lastName": "${familyEmail.lastName}",
+                "phoneNumber": "${familyEmail.phoneNumber}",
+                "iconImageUrl": "${familyEmail.iconImageUrl}"
+            }
+            """.trimIndent()))
     }
 
     @Test
     fun `should return 400 when user not found`() {
         val familyEmail = FamilyEmailPostRequest(
             email = "sample@sample.com",
-            firstName = "test",
-            lastName = "test",
+            firstName = "山田",
+            lastName = "太郎",
             phoneNumber = "09012345678",
             iconImageUrl = "http://example.com/icon.png"
         )

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailPostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailPostTest.kt
@@ -77,7 +77,7 @@ class FamilyEmailPostTest {
             phoneNumber = "09012345678",
             iconImageUrl = "http://example.com/icon.png"
         )
-        val userID = ""
+        val userID = "notfound"
 
         val result = mockMvc.perform(
             MockMvcRequestBuilders.post("/family_emails").headers(HttpHeaders().apply {

--- a/api-server/src/test/kotlin/com/unicorn/api/domain/family_email/FamilyEmailTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/domain/family_email/FamilyEmailTest.kt
@@ -9,14 +9,14 @@ class FamilyEmailTest {
     @Test
     fun `should create family email`() {
         val familyEmail = FamilyEmail.create(
-            familyEmailID = UUID.randomUUID(),
+            userID = "test",
             email = "sample@sample.com",
             firstName = "太郎",
             lastName = "山田",
             phoneNumber = "09012345678",
             iconImageUrl = "http://example.com/icon.png"
         )
-        assertEquals(familyEmail.familyEmailID.value, familyEmail.familyEmailID.value)
+        assertEquals("test", familyEmail.userID.value)
         assertEquals("sample@sample.com", familyEmail.email.value)
         assertEquals("太郎", familyEmail.firstName.value)
         assertEquals("山田", familyEmail.lastName.value)
@@ -28,6 +28,7 @@ class FamilyEmailTest {
     fun `should create family email from store`() {
         val familyEmail = FamilyEmail.fromStore(
             familyEmailID = UUID.randomUUID(),
+            userID = "test",
             email = "sample@sample.com",
             firstName = "太郎",
             lastName = "山田",
@@ -36,6 +37,7 @@ class FamilyEmailTest {
         )
 
         assertEquals(familyEmail.familyEmailID.value, familyEmail.familyEmailID.value)
+        assertEquals("test", familyEmail.userID.value)
         assertEquals("sample@sample.com", familyEmail.email.value)
         assertEquals("太郎", familyEmail.firstName.value)
         assertEquals("山田", familyEmail.lastName.value)
@@ -46,7 +48,7 @@ class FamilyEmailTest {
     @Test
     fun `should update family email`() {
         val familyEmail = FamilyEmail.create(
-            familyEmailID = UUID.randomUUID(),
+            userID = "test",
             email = "sample@sample.com",
             firstName = "太郎",
             lastName = "山田",
@@ -68,25 +70,10 @@ class FamilyEmailTest {
     }
 
     @Test
-    fun `should return an error message when null UUID`() {
-        val exception = assertThrows(IllegalArgumentException::class.java) {
-            FamilyEmail.create(
-                familyEmailID = UUID(0L,0L),
-                email = "sample@sample.com",
-                firstName = "太郎",
-                lastName = "山田",
-                phoneNumber = "09012345678",
-                iconImageUrl = "http://example.com/icon.png"
-            )
-        }
-        assertEquals("familyEmailID should not be null UUID", exception.message)
-    }
-
-    @Test
     fun `should return an error message when null email`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
             FamilyEmail.create(
-                familyEmailID = UUID.randomUUID(),
+                userID = "test",
                 email = "",
                 firstName = "太郎",
                 lastName = "山田",
@@ -101,7 +88,7 @@ class FamilyEmailTest {
     fun `should return an error message when null fimilyFirstName`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
             FamilyEmail.create(
-                familyEmailID = UUID.randomUUID(),
+                userID = "test",
                 email = "sample@sample.com",
                 firstName = "",
                 lastName = "山田",
@@ -116,7 +103,7 @@ class FamilyEmailTest {
     fun `should return an error message when null fimilyLastName`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
             FamilyEmail.create(
-                familyEmailID = UUID.randomUUID(),
+                userID = "test",
                 email = "sample@sample.com",
                 firstName = "太郎",
                 lastName = "",
@@ -131,7 +118,7 @@ class FamilyEmailTest {
     fun `should return an error message when null phoneNumber`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
             FamilyEmail.create(
-                familyEmailID = UUID.randomUUID(),
+                userID = "test",
                 email = "sample@sample.com",
                 firstName = "太郎",
                 lastName = "山田",

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
@@ -1,7 +1,6 @@
  package com.unicorn.api.infrastructure.family_email
 
 import com.unicorn.api.domain.family_email.*
-import com.unicorn.api.domain.user.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
@@ -49,6 +48,7 @@ class FamilyEmailRepositoryTest {
         return namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
             FamilyEmail.fromStore(
                 familyEmailID = UUID.fromString(rs.getString("family_email_id")),
+                userID = rs.getString("user_id"),
                 email = rs.getString("email"),
                 firstName = rs.getString("family_first_name"),
                 lastName = rs.getString("family_last_name"),
@@ -61,17 +61,18 @@ class FamilyEmailRepositoryTest {
     @Test
     fun `should store family email`() {
         val familyEmail = FamilyEmail.create(
-            familyEmailID = UUID.randomUUID(),
+            userID = "test",
             email = "test2@example.com",
             firstName = "test",
             lastName = "test",
             phoneNumber = "07012345678",
             iconImageUrl = "http://example.com/icon.png"
         )
-        val userID = UserID("test")
-        FamilyEmailRepository.store(familyEmail, userID)
+        
+
+        FamilyEmailRepository.store(familyEmail)
         val storedFamilyEmail = findFamilyEmailByID(familyEmail.familyEmailID.value)
-        assertEquals(familyEmail.familyEmailID, storedFamilyEmail?.familyEmailID)
+        assertEquals(familyEmail.userID, storedFamilyEmail?.userID)
         assertEquals(familyEmail.email, storedFamilyEmail?.email)
         assertEquals(familyEmail.firstName, storedFamilyEmail?.firstName)
         assertEquals(familyEmail.lastName, storedFamilyEmail?.lastName)
@@ -80,24 +81,32 @@ class FamilyEmailRepositoryTest {
     }
     @Test
     fun `should update family email`() {
-        val familyEmail = FamilyEmail.create(
+        val familyEmail = FamilyEmail.fromStore(
             familyEmailID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470"),
-            email = "test@test.com",
-            firstName = "test",
-            lastName = "test",
-            phoneNumber = "07012345678",
-            iconImageUrl = "http://example.com/icon.png"
+            userID = "test",
+            email = "sample@sample.com",
+            firstName = "太郎",
+            lastName = "山田",
+            phoneNumber = "09012345678",
+            iconImageUrl = "https://example.com"
         )
-        val userID = UserID("test")
-        FamilyEmailRepository.store(familyEmail, userID)
+        val updatedFamilyEmail = familyEmail.update(
+            email = Email("test@example.com"),
+            firstName = FirstName("John"),
+            lastName = LastName("Doe"),
+            phoneNumber = PhoneNumber("08087654321"),
+            iconImageUrl = IconImageUrl("http://example.com/newicon.png")
+        )
+        FamilyEmailRepository.store(updatedFamilyEmail)
 
         val result = findFamilyEmailByID(familyEmail.familyEmailID.value)
         assertEquals(familyEmail.familyEmailID, result?.familyEmailID)
-        assertEquals(familyEmail.email, result?.email)
-        assertEquals(familyEmail.firstName, result?.firstName)
-        assertEquals(familyEmail.lastName, result?.lastName)
-        assertEquals(familyEmail.phoneNumber, result?.phoneNumber)
-        assertEquals(familyEmail.iconImageUrl, result?.iconImageUrl)
+        assertEquals(familyEmail.userID, result?.userID)
+        assertEquals(updatedFamilyEmail.email, result?.email)
+        assertEquals(updatedFamilyEmail.firstName, result?.firstName)
+        assertEquals(updatedFamilyEmail.lastName, result?.lastName)
+        assertEquals(updatedFamilyEmail.phoneNumber, result?.phoneNumber)
+        assertEquals(updatedFamilyEmail.iconImageUrl, result?.iconImageUrl)
     }
 
     @Test
@@ -130,15 +139,14 @@ class FamilyEmailRepositoryTest {
     @Test
     fun `should delete family email`() {
         val familyEmail = FamilyEmail.create(
-            familyEmailID = UUID.randomUUID(),
+            userID = "test",
             email = "sample@sample.com",
             firstName = "太郎",
             lastName = "山田",
             phoneNumber = "09012345678",
             iconImageUrl = "http://example.com/icon.png"
         )
-        val userID = UserID("test")
-        FamilyEmailRepository.store(familyEmail, userID)
+        FamilyEmailRepository.store(familyEmail)
         FamilyEmailRepository.delete(familyEmail)
         val deletedFamilyEmail = FamilyEmailRepository.getOrNullBy(familyEmail.familyEmailID)
         assertNull(deletedFamilyEmail)


### PR DESCRIPTION
## 概要
- 家族メールアドレス情報を登録できるAPIを実装する
- 家族メールアドレスが適切に登録できているかどうかを確認するテストを行う

## 変更点
- contorollerのFamilyEmailController.ktにPOST機能を追加
- application_serviceのSaveFamilyEmailService.ktを追加
- POSTのテストを行うFamilyEmailPostTest.ktを追加

## 確認したこと
- テストが通ることを確認
- ローカル環境で家族メール情報の登録ができることを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
