### PR TITLE
[TKS-188] family_emailのDELETE実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/DeleteFamilyEmailService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/DeleteFamilyEmailService.kt
@@ -1,0 +1,27 @@
+package com.unicorn.api.application_service.family_email
+
+import com.unicorn.api.domain.family_email.FamilyEmailID
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.family_email.FamilyEmailRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteFamilyEmailService {
+    fun delete(familyEmailID: FamilyEmailID, userID: UserID): Unit
+}
+
+@Service
+class DeleteFamilyEmailServiceImpl(
+    private val familyEmailRepository: FamilyEmailRepository,
+    private val userRepository: UserRepository
+) : DeleteFamilyEmailService {
+    override fun delete(familyEmailID: FamilyEmailID, userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        val familyEmail = familyEmailRepository.getOrNullBy(familyEmailID)
+        requireNotNull(familyEmail) { "Family email not found" }
+
+        familyEmailRepository.delete(familyEmail)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -59,9 +59,9 @@ class FamilyEmailController(
     }
 
     @DeleteMapping("/family_emails/{familyEmailID}")
-    fun delete(@RequestHeader("X-UID") uid: String, @PathVariable familyEmailID: String): ResponseEntity<Any> {
+    fun delete(@RequestHeader("X-UID") uid: String, @PathVariable familyEmailID: UUID): ResponseEntity<Any> {
         try {
-            deleteFamilyEmailService.delete(FamilyEmailID(UUID.fromString(familyEmailID)), UserID(uid))
+            deleteFamilyEmailService.delete(FamilyEmailID(familyEmailID), UserID(uid))
             return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -7,6 +7,7 @@ import com.unicorn.api.query_service.user.UserQueryService
 import com.unicorn.api.query_service.family_email.FamilyEmailQueryService
 import com.unicorn.api.application_service.family_email.SaveFamilyEmailService
 import com.unicorn.api.application_service.family_email.UpdateFamilyEmailService
+import com.unicorn.api.application_service.family_email.DeleteFamilyEmailService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
@@ -17,7 +18,8 @@ class FamilyEmailController(
     private val userQueryService: UserQueryService,
     private val familyEmailQueryService: FamilyEmailQueryService,
     private val saveFamilyEmailService: SaveFamilyEmailService,
-    private val updateFamilyEmailService: UpdateFamilyEmailService
+    private val updateFamilyEmailService: UpdateFamilyEmailService,
+    private val deleteFamilyEmailService: DeleteFamilyEmailService
 ) {
     @GetMapping("/family_emails")
     fun get(@RequestHeader("X-UID") uid: String): ResponseEntity<*> {
@@ -55,7 +57,19 @@ class FamilyEmailController(
             return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
-}
+
+    @DeleteMapping("/family_emails/{familyEmailID}")
+    fun delete(@RequestHeader("X-UID") uid: String, @PathVariable familyEmailID: String): ResponseEntity<Any> {
+        try {
+            deleteFamilyEmailService.delete(FamilyEmailID(UUID.fromString(familyEmailID)), UserID(uid))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+}       
 
 data class FamilyEmailPostRequest(
     val email: String,

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailDeleteTest.kt
@@ -1,0 +1,79 @@
+package com.unicorn.api.application_service.family_email
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/user/Insert_Deleted_User_Data.sql")
+@Sql("/db/family_email/Insert_FamilyEmail_Data.sql")
+
+class FamilyEmailDeleteTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when family email is deleted`() {
+        val familyEmailID = "f47ac10b-58cc-4372-a567-0e02b2c3d470"
+        val userID = "test"
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/family_emails/${familyEmailID}")
+                .headers(HttpHeaders().apply {
+                    add("X-UID", userID)
+                })
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when family email not found`() {
+        val familyEmailID = "f47ac10b-58cc-4372-a567-0e02b2c3d472"
+        val userID = "test"
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/family_emails/${familyEmailID}")
+                .headers(HttpHeaders().apply {
+                    add("X-UID", userID)
+                })
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+        result.andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val familyEmailID = "f47ac10b-58cc-4372-a567-0e02b2c3d470"
+        val userID = "notfound"
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/family_emails/${familyEmailID}")
+                .headers(HttpHeaders().apply {
+                    add("X-UID", userID)
+                })
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+        result.andExpect(status().isBadRequest)
+    }
+}


### PR DESCRIPTION
## 概要
- 家族メールアドレス情報を削除するAPIを実装する
- 家族メールアドレスが適切に削除できているかどうかを確認するテストを行う

## 変更点
- ControllerのFamilyEmailController.ktに削除機能を追加
- ApplicationServiceのDeleteFamilyEmailService.ktを追加
- DELETEのテストを行うFamilyEmailDeleteTest.ktを追加

## 確認したこと
- テストが通ることを確認
- ローカル環境で削除ができたことを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
