### PR TITLE
[TSK-192] おくすり情報削除機能の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/medicine/DeleteMedicineService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/medicine/DeleteMedicineService.kt
@@ -1,0 +1,33 @@
+package com.unicorn.api.application_service.medicine
+
+import com.unicorn.api.domain.medicine.MedicineID
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.medicine.MedicineRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteMedicineService {
+    fun delete(userID: UserID, medicineID: MedicineID): Unit
+}
+
+@Service
+class DeleteMedicineServiceImpl(
+    private val userRepository: UserRepository,
+    private val medicineRepository: MedicineRepository
+) : DeleteMedicineService {
+    override fun delete(userID: UserID, medicineID: MedicineID) {
+        val user = userRepository.getOrNullBy(userID)
+
+        requireNotNull(user) {
+            "User not found"
+        }
+
+        val medicine = medicineRepository.getOrNullBy(medicineID)
+
+        requireNotNull(medicine) {
+            "Medicine not found"
+        }
+
+        medicineRepository.delete(medicine)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -1,5 +1,6 @@
 package com.unicorn.api.controller.medicine
 
+import com.unicorn.api.application_service.medicine.DeleteMedicineService
 import com.unicorn.api.application_service.medicine.SaveMedicineService
 import com.unicorn.api.application_service.medicine.UpdateMedicineService
 import com.unicorn.api.controller.api_response.ResponseError
@@ -18,7 +19,8 @@ class MedicineController(
     private val medicineQueryService: MedicineQueryService,
     private val userQueryService: UserQueryService,
     private val saveMedicineService: SaveMedicineService,
-    private val updateMedicineService: UpdateMedicineService
+    private val updateMedicineService: UpdateMedicineService,
+    private val deleteMedicineService: DeleteMedicineService
 ) {
     @GetMapping("/medicines")
     fun getMedicines(@RequestHeader("X-UID") uid: String): ResponseEntity<*> {
@@ -58,6 +60,18 @@ class MedicineController(
         try {
             val result = updateMedicineService.update(MedicineID(medicineID), UserID(uid), medicinePutRequest)
             return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/medicines/{medicineID}")
+    fun delete(@RequestHeader("X-UID") uid: String, @PathVariable medicineID: UUID): ResponseEntity<Any> {
+        try {
+            deleteMedicineService.delete(UserID(uid), MedicineID(medicineID))
+            return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
         } catch (e: Exception) {

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/medicine/MedicineRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/medicine/MedicineRepository.kt
@@ -1,6 +1,5 @@
 package com.unicorn.api.infrastructure.medicine
 
-import com.unicorn.api.domain.account.UID
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicineDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicineDeleteTest.kt
@@ -1,0 +1,72 @@
+package com.unicorn.api.controller.medicine
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/medicine/Insert_Medicine_Data.sql")
+class MedicineDeleteTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when medicine is deleted`() {
+        val userID = "test"
+        val medicineID = "123e4567-e89b-12d3-a456-426614174000"
+
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/medicines/$medicineID").headers(HttpHeaders().apply {
+                add("X-UID", userID)
+            })
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user ID is invalid`() {
+        val medicineID = "123e4567-e89b-12d3-a456-426614174001"
+        val invalidUserID = "invalid-id"
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/medicines/$medicineID").headers(HttpHeaders().apply {
+                add("X-UID", invalidUserID)
+            })
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when medicine ID is invalid`() {
+        val invalidMedicineID = "invalid-id"
+        val userID = "test"
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/medicines/$invalidMedicineID").headers(HttpHeaders().apply {
+                add("X-UID", userID)
+            })
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isBadRequest)
+    }
+}


### PR DESCRIPTION
## 概要
medicineID を使用した medicine 削除機能の実装

## 変更点
- MedicineController に追記。
- DeleteMedicineService を追加。
- 対応するテストを追加。

## 確認したこと
- 論理削除であること。
- テストが通ること。