### PR TITLE
feat: health_checkupのdomainとrepositoryの実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/domain/health_checkup/HealthCheckup.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/domain/health_checkup/HealthCheckup.kt
@@ -1,0 +1,95 @@
+package com.unicorn.api.domain.health_checkup
+
+import com.unicorn.api.domain.user.UserID
+import java.util.*
+
+data class HealthCheckup private constructor(
+    val healthCheckupID: HealthCheckupID,
+    val userID: UserID,
+    val bodyTemperature: BodyTemperature,
+    val bloodPressure: BloodPressure,
+    val medicalRecord: MedicalRecord,
+    val date: CheckupedDate
+) {
+    companion object {
+        fun fromStore(
+            healthCheckupID: UUID,
+            userID: String,
+            bodyTemperature: Double,
+            bloodPressure: String,
+            medicalRecord: String,
+            date: String
+        ): HealthCheckup{ 
+            return HealthCheckup(
+                healthCheckupID = HealthCheckupID(healthCheckupID),
+                userID = UserID(userID),
+                bodyTemperature = BodyTemperature(bodyTemperature),
+                bloodPressure = BloodPressure(bloodPressure),
+                medicalRecord = MedicalRecord(medicalRecord),
+                date = CheckupedDate(date)
+            )
+        }
+
+        fun create(
+            userID: String,
+            bodyTemperature: Double,
+            bloodPressure: String,
+            medicalRecord: String,
+            date: String
+        ): HealthCheckup {
+            return HealthCheckup(
+                healthCheckupID = HealthCheckupID(UUID.randomUUID()),
+                userID = UserID(userID),
+                bodyTemperature = BodyTemperature(bodyTemperature),
+                bloodPressure = BloodPressure(bloodPressure),
+                medicalRecord = MedicalRecord(medicalRecord),
+                date = CheckupedDate(date)
+            )
+        }
+    }
+
+    fun update(
+        bodyTemperature: BodyTemperature,
+        bloodPressure: BloodPressure,
+        medicalRecord: MedicalRecord,
+        date: CheckupedDate
+    ): HealthCheckup {
+        return this.copy(
+            bodyTemperature = bodyTemperature,
+            bloodPressure = bloodPressure,
+            medicalRecord = medicalRecord,
+            date = date
+        )
+    }
+}
+
+@JvmInline
+value class HealthCheckupID(val value: UUID)
+
+@JvmInline
+value class BodyTemperature(val value: Double){
+    init {
+        require(value > 0){"body temperature should be greater than 0"}
+    }
+}
+
+@JvmInline
+value class BloodPressure(val value: String){
+    init {
+        require(value.isNotBlank()){"blood pressure should not be blank"}
+    }
+}
+
+@JvmInline
+value class MedicalRecord(val value: String){
+    init {
+        require(value.isNotBlank()){"medical record should not be blank"}
+    }
+}
+
+@JvmInline
+value class CheckupedDate(val value: String){
+    init {
+        require(value.isNotBlank()){"date should not be blank"}
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/health_checkup/HealthCheckupRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/health_checkup/HealthCheckupRepository.kt
@@ -1,0 +1,112 @@
+package com.unicorn.api.infrastructure.health_checkup
+
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.domain.health_checkup.*
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.util.*
+
+interface HealthCheckupRepository {
+    fun store(healthCheckup: HealthCheckup): HealthCheckup
+    fun getOrNullBy(healthCheckupID: HealthCheckupID): HealthCheckup?
+    fun delete(healthCheckup: HealthCheckup)
+}
+
+@Repository
+class HealthCheckupRepositoryImpl(
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+) : HealthCheckupRepository {
+
+    override fun store(healthCheckup: HealthCheckup): HealthCheckup {
+        // laguage=postgresql
+        val sql = """
+            INSERT INTO health_checkups(
+                health_checkup_id,
+                checkuped_user_id,
+                body_temperature,
+                blood_pressure,
+                medical_record,
+                checkuped_date,
+                created_at
+            ) VALUES (
+                :healthCheckupID,
+                :userID,
+                :bodyTemperature,
+                :bloodPressure,
+                :medicalRecord,
+                :date,
+                NOW()
+            )
+            ON CONFLICT (health_checkup_id)
+            DO UPDATE SET
+                body_temperature = EXCLUDED.body_temperature,
+                blood_pressure = EXCLUDED.blood_pressure,
+                medical_record = EXCLUDED.medical_record,
+                checkuped_date = EXCLUDED.checkuped_date,
+                deleted_at = NULL
+            WHERE health_checkups.created_at IS NOT NULL
+        """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource()
+            .addValue("healthCheckupID", healthCheckup.healthCheckupID.value)
+            .addValue("userID", healthCheckup.userID.value)
+            .addValue("bodyTemperature", healthCheckup.bodyTemperature.value)
+            .addValue("bloodPressure", healthCheckup.bloodPressure.value)
+            .addValue("medicalRecord", healthCheckup.medicalRecord.value)
+            .addValue("date", LocalDate.parse(healthCheckup.date.value))
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+
+        return healthCheckup
+    }
+
+    override fun getOrNullBy(healthCheckupID: HealthCheckupID): HealthCheckup? {
+        //language=postgresql
+        val sql = """
+            SELECT
+                health_checkup_id,
+                checkuped_user_id,
+                body_temperature,
+                blood_pressure,
+                medical_record,
+                checkuped_date
+            FROM health_checkups
+            WHERE health_checkup_id = :healthCheckupID
+            AND deleted_at IS NULL
+        """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource()
+            .addValue("healthCheckupID", healthCheckupID.value)
+        
+        return namedParameterJdbcTemplate.query(
+            sql,
+            sqlParams
+        ) { rs, _ ->
+            HealthCheckup.fromStore(
+                healthCheckupID = UUID.fromString(rs.getString("health_checkup_id")),
+                userID = rs.getString("checkuped_user_id"),
+                bodyTemperature = rs.getDouble("body_temperature"),
+                bloodPressure = rs.getString("blood_pressure"),
+                medicalRecord = rs.getString("medical_record"),
+                date = rs.getString("checkuped_date")
+            )
+        }.singleOrNull()
+    }
+
+    override fun delete(healthCheckup: HealthCheckup) {
+        // language=postgresql
+        val sql = """
+            UPDATE health_checkups
+            SET deleted_at = NOW()
+            WHERE health_checkup_id = :healthCheckupID
+            AND deleted_at IS NULL
+        """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource()
+            .addValue("healthCheckupID", healthCheckup.healthCheckupID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+}

--- a/api-server/src/main/resources/db/migration/V026__Refactor_HealthCheckups_table.sql
+++ b/api-server/src/main/resources/db/migration/V026__Refactor_HealthCheckups_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE health_checkups ADD COLUMN checkuped_date DATE NOT NULL

--- a/api-server/src/test/kotlin/com/unicorn/api/domain/health_checkup/HealthCheckupTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/domain/health_checkup/HealthCheckupTest.kt
@@ -1,0 +1,121 @@
+package com.unicorn.api.domain.health_checkup
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class HealthCheckupTest {
+    @Test
+    fun `should create health checkup`() {
+        val healthCheckup = HealthCheckup.create(
+            userID = "test",
+            bodyTemperature = 36.5,
+            bloodPressure = "120/80",
+            medicalRecord = "test",
+            date = "2021-01-01"
+        )
+
+        assertEquals("test", healthCheckup.userID.value)
+        assertEquals(36.5, healthCheckup.bodyTemperature.value)
+        assertEquals("120/80", healthCheckup.bloodPressure.value)
+        assertEquals("test", healthCheckup.medicalRecord.value)
+        assertEquals("2021-01-01", healthCheckup.date.value)
+    }
+
+    @Test
+    fun `should create health checkup from store`() {
+        val healthCheckup = HealthCheckup.fromStore(
+            healthCheckupID = UUID.randomUUID(),
+            userID = "test",
+            bodyTemperature = 36.5,
+            bloodPressure = "120/80",
+            medicalRecord = "test",
+            date = "2021-01-01"
+        )
+
+        assertEquals("test", healthCheckup.userID.value)
+        assertEquals(36.5, healthCheckup.bodyTemperature.value)
+        assertEquals("120/80", healthCheckup.bloodPressure.value)
+        assertEquals("test", healthCheckup.medicalRecord.value)
+        assertEquals("2021-01-01", healthCheckup.date.value)
+    }
+
+    @Test
+    fun `should update health checkup`() {
+        val healthCheckup = HealthCheckup.create(
+            userID = "test",
+            bodyTemperature = 36.5,
+            bloodPressure = "120/80",
+            medicalRecord = "test",
+            date = "2021-01-01"
+        )
+
+        val updatedHealthCheckup = healthCheckup.update(
+            bodyTemperature = BodyTemperature(37.5),
+            bloodPressure = BloodPressure("130/90"),
+            medicalRecord = MedicalRecord("updated test"),
+            date = CheckupedDate("2021-01-02")
+        )
+
+        assertEquals(37.5, updatedHealthCheckup.bodyTemperature.value)
+        assertEquals("130/90", updatedHealthCheckup.bloodPressure.value)
+        assertEquals("updated test", updatedHealthCheckup.medicalRecord.value)
+        assertEquals("2021-01-02", updatedHealthCheckup.date.value)
+    }
+
+    @Test
+    fun `should return an error message when null body temperature`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            HealthCheckup.create(
+                userID = "test",
+                bodyTemperature = 0.0,
+                bloodPressure = "120/80",
+                medicalRecord = "test",
+                date = "2021-01-01"
+            )
+        }
+        assertEquals("body temperature should be greater than 0", exception.message)
+    }
+
+    @Test
+    fun `should return an error message when null blood pressure`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            HealthCheckup.create(
+                userID = "test",
+                bodyTemperature = 36.5,
+                bloodPressure = "",
+                medicalRecord = "test",
+                date = "2021-01-01"
+            )
+        }
+        assertEquals("blood pressure should not be blank", exception.message)
+    }
+
+    @Test
+    fun `should return an error message when null medical record`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            HealthCheckup.create(
+                userID = "test",
+                bodyTemperature = 36.5,
+                bloodPressure = "120/80",
+                medicalRecord = "",
+                date = "2021-01-01"
+            )
+        }
+        assertEquals("medical record should not be blank", exception.message)
+    }
+
+    @Test
+    fun `should return an error message when null date`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            HealthCheckup.create(
+                userID = "test",
+                bodyTemperature = 36.5,
+                bloodPressure = "120/80",
+                medicalRecord = "test",
+                date = ""
+            )
+        }
+        assertEquals("date should not be blank", exception.message)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/health_checkup/HealthCheckupRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/health_checkup/HealthCheckupRepositoryTest.kt
@@ -1,0 +1,150 @@
+package com.unicorn.api.infrastructure.health_checkup
+
+import com.unicorn.api.domain.health_checkup.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.transaction.annotation.Transactional
+import org.junit.jupiter.api.Assertions.*
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/health_checkup/Insert_HealthCheckup_Data.sql")
+
+class HealthCheckupRepositoryTest {
+    @Autowired
+    private lateinit var healthCheckupRepository: HealthCheckupRepository
+    @Autowired
+    private lateinit var namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+
+    private fun findHealthCheckupByID(healthCheckupID: UUID): HealthCheckup? {
+        //language=postgresql
+        val sql = """
+            SELECT
+                health_checkup_id,
+                checkuped_user_id,
+                body_temperature,
+                blood_pressure,
+                medical_record,
+                checkuped_date
+            FROM health_checkups
+            WHERE health_checkup_id = :healthCheckupID
+            AND deleted_at IS NULL
+        """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource()
+            .addValue("healthCheckupID", healthCheckupID)
+
+        return namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
+            HealthCheckup.fromStore(
+                healthCheckupID = UUID.fromString(rs.getString("health_checkup_id")),
+                userID = rs.getString("checkuped_user_id"),
+                bodyTemperature = rs.getDouble("body_temperature"),
+                bloodPressure = rs.getString("blood_pressure"),
+                medicalRecord = rs.getString("medical_record"),
+                date = rs.getString("checkuped_date")
+            )
+        }.singleOrNull()
+    }
+
+    @Test
+    fun `should store health checkup`() {
+        val healthCheckup = HealthCheckup.create(
+            userID = "test",
+            bodyTemperature = 36.5,
+            bloodPressure = "120/80",
+            medicalRecord = "test",
+            date = "2021-01-01"
+        )
+        healthCheckupRepository.store(healthCheckup)
+        val storedHealthCheckup = findHealthCheckupByID(healthCheckup.healthCheckupID.value)
+        assertEquals(healthCheckup.userID, storedHealthCheckup?.userID)
+        assertEquals(healthCheckup.bodyTemperature, storedHealthCheckup?.bodyTemperature)
+        assertEquals(healthCheckup.bloodPressure, storedHealthCheckup?.bloodPressure)
+        assertEquals(healthCheckup.medicalRecord, storedHealthCheckup?.medicalRecord)
+        assertEquals(healthCheckup.date, storedHealthCheckup?.date)
+    }
+
+    @Test
+    fun `should update health checkup`() {
+        val healthCheckup = HealthCheckup.fromStore(
+            healthCheckupID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470"),
+            userID = "test",
+            bodyTemperature = 36.5,
+            bloodPressure = "120/80",
+            medicalRecord = "sample medical record",
+            date = "2021-01-01"
+        )
+
+        val updatedHealthCheckup = healthCheckup.update(
+            bodyTemperature = BodyTemperature(37.5),
+            bloodPressure = BloodPressure("130/90"),
+            medicalRecord = MedicalRecord("updated medical record"),
+            date = CheckupedDate("2021-01-02")
+        )
+
+        healthCheckupRepository.store(updatedHealthCheckup)
+
+        val storedHealthCheckup = findHealthCheckupByID(healthCheckup.healthCheckupID.value)
+        assertEquals(healthCheckup.healthCheckupID, storedHealthCheckup?.healthCheckupID)
+        assertEquals(healthCheckup.userID, storedHealthCheckup?.userID)
+        assertEquals(updatedHealthCheckup.bodyTemperature, storedHealthCheckup?.bodyTemperature)
+        assertEquals(updatedHealthCheckup.bloodPressure, storedHealthCheckup?.bloodPressure)
+        assertEquals(updatedHealthCheckup.medicalRecord, storedHealthCheckup?.medicalRecord)
+        assertEquals(updatedHealthCheckup.date, storedHealthCheckup?.date)
+    }
+
+    @Test
+    fun `should find health checkup by ID`() {
+        val healthCheckupID = HealthCheckupID(UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470"))
+        val foundHealthCheckup = healthCheckupRepository.getOrNullBy(healthCheckupID)
+        assertNotNull(foundHealthCheckup)
+        assertEquals(healthCheckupID, foundHealthCheckup!!.healthCheckupID)
+        assertEquals("test", foundHealthCheckup.userID.value)
+        assertEquals(36.5, foundHealthCheckup.bodyTemperature.value)
+        assertEquals("120/80", foundHealthCheckup.bloodPressure.value)
+        assertEquals("sample medical record", foundHealthCheckup.medicalRecord.value)
+        assertEquals("2020-01-01", foundHealthCheckup.date.value)
+    }
+
+    @Test
+    fun `should not be found if deleted_at is not NULL`() {
+        val healthCheckupID = HealthCheckupID(UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d471"))
+        val foundHealthCheckup = healthCheckupRepository.getOrNullBy(healthCheckupID)
+        assertNull(foundHealthCheckup)
+    }
+
+    @Test
+    fun ` should return null when health checkup does not exist`() {
+        val healthCheckupID = HealthCheckupID(UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d472"))
+        val foundHealthCheckup = healthCheckupRepository.getOrNullBy(healthCheckupID)
+        assertNull(foundHealthCheckup)
+    }
+
+    @Test
+    fun `Should delete health checkup`() {
+        val healthCheckup = HealthCheckup.create(
+            userID = "test",
+            bodyTemperature = 36.5,
+            bloodPressure = "120/80",
+            medicalRecord = "test",
+            date = "2021-01-01"
+        )
+
+        healthCheckupRepository.store(healthCheckup)
+        healthCheckupRepository.delete(healthCheckup)
+        val foundHealthCheckup = healthCheckupRepository.getOrNullBy(healthCheckup.healthCheckupID)
+        assertNull(foundHealthCheckup)
+    }
+
+}

--- a/api-server/src/test/resources/db/health_checkup/Insert_HealthCheckup_Data.sql
+++ b/api-server/src/test/resources/db/health_checkup/Insert_HealthCheckup_Data.sql
@@ -1,0 +1,28 @@
+INSERT INTO health_checkups (
+    "health_checkup_id",
+    "checkuped_user_id",
+    "body_temperature",
+    "blood_pressure",
+    "medical_record",
+    "checkuped_date",
+    "created_at",
+    "deleted_at"
+) VALUES (
+    'f47ac10b-58cc-4372-a567-0e02b2c3d470',
+    'test',
+    36.5,
+    '120/80',
+    'sample medical record',
+    '2020-01-01',
+    NOW(),
+    null
+), (
+    'f47ac10b-58cc-4372-a567-0e02b2c3d471',
+    'test',
+    36.5,
+    '120/80',
+    'sample medical record',
+    '2020-01-01',
+    NOW(),
+    NOW()
+);


### PR DESCRIPTION
## 概要
- 検査情報のdomainとrepositoryを実装する
- 検査情報のdomainとrepositoryが動作しているかどうかを確認するテストを行う

## 変更点
- domainのHealthCheckup.ktを追加
- infrastructureのHealthCheckupRepository.ktを追加
- health_checkupsテーブルにcheckuped_dateカラムを追加するSQLファイルを追加
- それぞれのテストファイルを追加
- テストに使うInsert文SQLファイルを追加

## 確認したこと
- テストが通ること

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
