### PR TITLE
[TSK-173] health_checkupのdelete機能実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/health_checkup/DeleteHealthCheckupService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/health_checkup/DeleteHealthCheckupService.kt
@@ -1,0 +1,33 @@
+package com.unicorn.api.application_service.health_checkup
+
+import com.unicorn.api.domain.health_checkup.HealthCheckupID
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.health_checkup.HealthCheckupRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteHealthCheckupService {
+    fun delete(
+        userID: UserID,
+        healthCheckupID: HealthCheckupID,
+    ): Unit
+}
+
+@Service
+class DeleteHealthCheckupServiceImpl(
+    private val userRepository: UserRepository,
+    private val healthCheckupRepository: HealthCheckupRepository,
+) : DeleteHealthCheckupService {
+    override fun delete(
+        userID: UserID,
+        healthCheckupID: HealthCheckupID,
+    ) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        val healthCheckup = healthCheckupRepository.getOrNullBy(healthCheckupID)
+        requireNotNull(healthCheckup) { "Health checkup not found" }
+
+        healthCheckupRepository.delete(healthCheckup)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
@@ -15,6 +15,7 @@ import java.util.*
 class HealthCheckupController(
     private val saveHealthCheckupService: SaveHealthCheckupService,
     private val updateHealthCheckupService: UpdateHealthCheckupService,
+    private val deleteHealthCheckupService: DeleteHealthCheckupService,
 ) {
     @PostMapping("/health_checkups")
     fun post(
@@ -40,6 +41,21 @@ class HealthCheckupController(
         try {
             val result = updateHealthCheckupService.update(UserID(uid), HealthCheckupID(healthCheckupID), healthCheckupPutRequest)
             return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/health_checkups/{healthCheckupID}")
+    fun delete(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable healthCheckupID: UUID,
+    ): ResponseEntity<Any> {
+        try {
+            deleteHealthCheckupService.delete(UserID(uid), HealthCheckupID(healthCheckupID))
+            return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
         } catch (e: Exception) {

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupDeleteTest.kt
@@ -1,0 +1,102 @@
+package com.unicorn.api.controller.health_checkup
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/user/Insert_Deleted_User_Data.sql")
+@Sql("/db/health_checkup/Insert_HealthCheckup_Data.sql")
+class HealthCheckupDeleteTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete health checkup`() {
+        val healthCheckupID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470")
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/health_checkups/$healthCheckupID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when health checkup not found`() {
+        val healthCheckupID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d472")
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/health_checkups/$healthCheckupID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val healthCheckupID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470")
+        val userID = "notfound"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/health_checkups/$healthCheckupID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when deleted health checkup is not found`() {
+        val healthCheckupID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d471")
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/health_checkups/$healthCheckupID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupDeleteTest.kt
@@ -11,6 +11,7 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -62,6 +63,17 @@ class HealthCheckupDeleteTest {
                     .contentType(MediaType.APPLICATION_JSON),
             )
         result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "Health checkup not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
     }
 
     @Test
@@ -80,6 +92,17 @@ class HealthCheckupDeleteTest {
                     .contentType(MediaType.APPLICATION_JSON),
             )
         result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
     }
 
     @Test
@@ -98,5 +121,16 @@ class HealthCheckupDeleteTest {
                     .contentType(MediaType.APPLICATION_JSON),
             )
         result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "Health checkup not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
     }
 }


### PR DESCRIPTION
## 概要
- 検査情報を削除するAPIを実装する
- 検査情報が適切に削除できているかどうかを確認するテストを行う

## 変更点
- Controllerにdeleteの機能を追加
- ApplicationServiceにDeleteHealthCheckupService.ktを追加
- DELETEのテストを行うテストファイルを追加

## 確認したこと
- テストが通ったことを確認
- ローカル環境で論理削除ができたことを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
