### PR TITLE
[TSK-169] health_checkupの一括取得実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
@@ -21,15 +21,16 @@ class HealthCheckupController(
     private val deleteHealthCheckupService: DeleteHealthCheckupService,
     private val healthCheckupQueryService: HealthCheckupQueryService,
 ) {
-    @GetMapping("/health_checkups")
+    @GetMapping("users/{userID}/health_checkups")
     fun get(
         @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
     ): ResponseEntity<*> {
         try {
-            userQueryService.getOrNullBy(uid)
+            userQueryService.getOrNullBy(userID)
                 ?: return ResponseEntity.badRequest().body(ResponseError("User not found"))
 
-            val result = healthCheckupQueryService.getBy(UserID(uid))
+            val result = healthCheckupQueryService.getBy(UserID(userID))
             return ResponseEntity.ok(result)
         } catch (e: Exception) {
             return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
@@ -21,6 +21,21 @@ class HealthCheckupController(
     private val deleteHealthCheckupService: DeleteHealthCheckupService,
     private val healthCheckupQueryService: HealthCheckupQueryService,
 ) {
+    @GetMapping("/health_checkups")
+    fun get(
+        @RequestHeader("X-UID") uid: String,
+    ): ResponseEntity<*> {
+        try {
+            userQueryService.getOrNullBy(uid)
+                ?: return ResponseEntity.badRequest().body(ResponseError("User not found"))
+
+            val result = healthCheckupQueryService.getBy(UserID(uid))
+            return ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
+
     @PostMapping("/health_checkups")
     fun post(
         @RequestHeader("X-UID") uid: String,

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/health_checkup/HealthCheckupQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/health_checkup/HealthCheckupQueryService.kt
@@ -97,5 +97,5 @@ data class HealthCheckupDto(
 )
 
 data class HealthCheckupResult(
-    val healthCheckups: List<HealthCheckupDto>,
+    val data: List<HealthCheckupDto>,
 )

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupGetsTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupGetsTest.kt
@@ -31,8 +31,8 @@ class HealthCheckupGetsTest {
         val result =
             mockMvc.perform(
                 MockMvcRequestBuilders
-                    .get("/health_checkups")
-                    .headers(HttpHeaders().apply { add("X-UID", userID) }),
+                    .get("/users/$userID/health_checkups")
+                    .headers(HttpHeaders().apply { add("X-UID", "uid") }),
             )
         result.andExpect(status().isOk)
         result.andExpect(
@@ -63,8 +63,8 @@ class HealthCheckupGetsTest {
         val result =
             mockMvc.perform(
                 MockMvcRequestBuilders
-                    .get("/health_checkups")
-                    .headers(HttpHeaders().apply { add("X-UID", userID) }),
+                    .get("/users/$userID/health_checkups")
+                    .headers(HttpHeaders().apply { add("X-UID", "uid") }),
             )
         result.andExpect(status().isBadRequest)
         result.andExpect(

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupGetsTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupGetsTest.kt
@@ -1,0 +1,82 @@
+package com.unicorn.api.controller.health_checkup
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/health_checkup/Insert_HealthCheckup_Data.sql")
+class HealthCheckupGetsTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should 200 when get all health checkup`() {
+        val userID = "test"
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders
+                    .get("/health_checkups")
+                    .headers(HttpHeaders().apply { add("X-UID", userID) }),
+            )
+        result.andExpect(status().isOk)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "data": [
+                        {
+                            "healthCheckupID": "f47ac10b-58cc-4372-a567-0e02b2c3d470",
+                            "userID": "$userID",
+                            "bodyTemperature": 36.5,
+                            "bloodPressure": "120/80",
+                            "medicalRecord": "sample medical record",
+                            "date": "2020-01-01"
+                        }
+                    ]
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+
+    @Test
+    fun `should 400 when user not found`() {
+        val userID = "notfound"
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders
+                    .get("/health_checkups")
+                    .headers(HttpHeaders().apply { add("X-UID", userID) }),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## 概要
- 検査情報を一覧取得するAPIを実装する
- 検査情報が適切に取得できているかどうかを確認するテストを行う

## 変更点
- Controllerに/health_checkupsのGETを追加
- 一括取得のテストを行うためのテストファイルを追加

## 確認したこと
- テストが通ることを確認
- ローカル環境で一括取得ができたことを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
