### PR TITLE
[TSK-194] chronic-diseaseの持病登録の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/chronic_disease/SaveChronicDiseaseService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/chronic_disease/SaveChronicDiseaseService.kt
@@ -1,0 +1,38 @@
+package com.unicorn.api.application_service.chronic_disease
+
+import com.unicorn.api.controller.chronic_disease.ChronicDiseasePostRequest
+import com.unicorn.api.domain.chronic_disease.ChronicDisease
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.chronic_disease.ChronicDiseaseRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+import java.util.*
+
+interface SaveChronicDiseaseService {
+    fun save(
+        userID: UserID,
+        chronicDiseasePostRequest: ChronicDiseasePostRequest,
+    ): ChronicDisease
+}
+
+@Service
+class SaveChronicDiseaseServiceImpl(
+    private val userRepository: UserRepository,
+    private val chronicDiseaseRepository: ChronicDiseaseRepository,
+) : SaveChronicDiseaseService {
+    override fun save(
+        userID: UserID,
+        chronicDiseasePostRequest: ChronicDiseasePostRequest,
+    ): ChronicDisease {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        val chronicDisease =
+            ChronicDisease.create(
+                userID = userID.value,
+                diseaseID = chronicDiseasePostRequest.diseaseID,
+            )
+        chronicDiseaseRepository.store(chronicDisease)
+        return chronicDisease
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
@@ -1,0 +1,33 @@
+package com.unicorn.api.controller.chronic_disease
+
+import com.unicorn.api.application_service.chronic_disease.*
+import com.unicorn.api.controller.api_response.ResponseError
+import com.unicorn.api.domain.user.UserID
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.*
+import java.util.*
+
+@Controller
+class ChronicDiseaseController(
+    private val saveChronicDiseaseService: SaveChronicDiseaseService,
+) {
+    @PostMapping("/chronic_disease")
+    fun post(
+        @RequestHeader("X-UID") uid: String,
+        @RequestBody chronicDiseasePostRequest: ChronicDiseasePostRequest,
+    ): ResponseEntity<*> {
+        try {
+            val result = saveChronicDiseaseService.save(UserID(uid), chronicDiseasePostRequest)
+            return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
+}
+
+data class ChronicDiseasePostRequest(
+    val diseaseID: Int,
+)

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseasePostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseasePostTest.kt
@@ -1,0 +1,102 @@
+package com.unicorn.api.controller.chronic_disease
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/disease/Insert_Disease_Data.sql")
+@Sql("/db/chronic_disease/Insert_Chronic_Disease_Data.sql")
+class ChronicDiseasePostTest {
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 200 when create chronic disease`() {
+        val chronicDisease =
+            ChronicDiseasePostRequest(
+                diseaseID = 1,
+            )
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/chronic_disease")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(chronicDisease)),
+            )
+        result.andExpect(status().isOk)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "userID": "$userID",
+                    "diseaseID": ${chronicDisease.diseaseID}
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val chronicDisease =
+            ChronicDiseasePostRequest(
+                diseaseID = 1,
+            )
+        val userID = "notfound"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/chronic_disease")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(chronicDisease)),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## 概要
- 持病情報を登録できるAPIを実装する
- 持病情報が適切に登録できているかどうかを確認するテストを行う

## 変更点
- ControllerのChronicDiseaseController.ktの追加
- ApplicationServiceのSaveChronicDiseaseService.ktの追加
- postのテストを行うテストファイルの追加

## 確認したこと
- テストが通ったことを確認
- ローカル環境で登録ができたことを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
