### PR TITLE
[TSK-195] chronic_diseaseの持病削除の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/chronic_disease/DeleteChronicDiseaseService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/chronic_disease/DeleteChronicDiseaseService.kt
@@ -1,0 +1,33 @@
+package com.unicorn.api.application_service.chronic_disease
+
+import com.unicorn.api.domain.chronic_disease.ChronicDiseaseID
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.chronic_disease.ChronicDiseaseRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteChronicDiseaseService {
+    fun delete(
+        userID: UserID,
+        chronicDiseaseID: ChronicDiseaseID,
+    ): Unit
+}
+
+@Service
+class DeleteChronicDiseaseServiceImpl(
+    private val userRepository: UserRepository,
+    private val chronicDiseaseRepository: ChronicDiseaseRepository,
+) : DeleteChronicDiseaseService {
+    override fun delete(
+        userID: UserID,
+        chronicDiseaseID: ChronicDiseaseID,
+    ) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        val chronicDisease = chronicDiseaseRepository.getOrNullBy(chronicDiseaseID)
+        requireNotNull(chronicDisease) { "Chronic disease not found" }
+
+        chronicDiseaseRepository.delete(chronicDisease)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.controller.chronic_disease
 
 import com.unicorn.api.application_service.chronic_disease.*
 import com.unicorn.api.controller.api_response.ResponseError
+import com.unicorn.api.domain.chronic_disease.ChronicDiseaseID
 import com.unicorn.api.domain.user.UserID
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
@@ -11,6 +12,7 @@ import java.util.*
 @Controller
 class ChronicDiseaseController(
     private val saveChronicDiseaseService: SaveChronicDiseaseService,
+    private val deleteChronicDiseaseService: DeleteChronicDiseaseService,
 ) {
     @PostMapping("/chronic_disease")
     fun post(
@@ -20,6 +22,21 @@ class ChronicDiseaseController(
         try {
             val result = saveChronicDiseaseService.save(UserID(uid), chronicDiseasePostRequest)
             return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/chronic_disease/{chronicDiseaseID}")
+    fun delete(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable chronicDiseaseID: UUID,
+    ): ResponseEntity<Any> {
+        try {
+            deleteChronicDiseaseService.delete(UserID(uid), ChronicDiseaseID(chronicDiseaseID))
+            return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
         } catch (e: Exception) {

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseDeleteTest.kt
@@ -1,0 +1,136 @@
+package com.unicorn.api.controller.chronic_disease
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/disease/Insert_Disease_Data.sql")
+@Sql("/db/chronic_disease/Insert_Chronic_Disease_Data.sql")
+class ChronicDiseaseDeleteTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete success`() {
+        val chronicDiseaseID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470")
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val chronicDiseaseID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d470")
+        val userID = "notfound"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+
+    @Test
+    fun `should return 400 when chronic disease not found`() {
+        val chronicDiseaseID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d472")
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "Chronic disease not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+
+    @Test
+    fun `should return 400 when deleted chronic disease is not found`() {
+        val chronicDiseaseID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d471")
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "Chronic disease not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## 概要
- 持病情報を削除するAPIを実装する
- 持病情報が適切に削除できているかどうかを確認するテストを行う

## 変更点
- ControllerにDELETEを追加
- ApplicationServiceにDeleteChronicDiseaseService.ktを追加
- DELETEのテストを行うテストファイルを追加

## 確認したこと
- テストが通ること
- ローカル環境で論理削除ができていること

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
