### PR TITLE
[TSK-193] chronic_diseaseの持病一覧取得の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
@@ -18,7 +18,7 @@ class ChronicDiseaseController(
     private val saveChronicDiseaseService: SaveChronicDiseaseService,
     private val deleteChronicDiseaseService: DeleteChronicDiseaseService,
 ) {
-    @GetMapping("/chronic_disease")
+    @GetMapping("/chronic_diseases")
     fun get(
         @RequestHeader("X-UID") uid: String,
     ): ResponseEntity<*> {
@@ -32,7 +32,7 @@ class ChronicDiseaseController(
         }
     }
 
-    @PostMapping("/chronic_disease")
+    @PostMapping("/chronic_diseases")
     fun post(
         @RequestHeader("X-UID") uid: String,
         @RequestBody chronicDiseasePostRequest: ChronicDiseasePostRequest,
@@ -47,7 +47,7 @@ class ChronicDiseaseController(
         }
     }
 
-    @DeleteMapping("/chronic_disease/{chronicDiseaseID}")
+    @DeleteMapping("/chronic_diseases/{chronicDiseaseID}")
     fun delete(
         @RequestHeader("X-UID") uid: String,
         @PathVariable chronicDiseaseID: UUID,

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
@@ -4,6 +4,8 @@ import com.unicorn.api.application_service.chronic_disease.*
 import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.chronic_disease.ChronicDiseaseID
 import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.query_service.chronic_disease.ChronicDiseaseQueryService
+import com.unicorn.api.query_service.user.UserQueryService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
@@ -11,9 +13,25 @@ import java.util.*
 
 @Controller
 class ChronicDiseaseController(
+    private val chronicDiseaseQueryService: ChronicDiseaseQueryService,
+    private val userQueryService: UserQueryService,
     private val saveChronicDiseaseService: SaveChronicDiseaseService,
     private val deleteChronicDiseaseService: DeleteChronicDiseaseService,
 ) {
+    @GetMapping("/chronic_disease")
+    fun get(
+        @RequestHeader("X-UID") uid: String,
+    ): ResponseEntity<*> {
+        try {
+            userQueryService.getOrNullBy(uid)
+                ?: return ResponseEntity.status(400).body(ResponseError("User not found"))
+            val result = chronicDiseaseQueryService.get(UserID(uid))
+            return ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
+
     @PostMapping("/chronic_disease")
     fun post(
         @RequestHeader("X-UID") uid: String,

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/chronic_disease/ChronicDiseaseQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/chronic_disease/ChronicDiseaseQueryService.kt
@@ -19,18 +19,18 @@ class ChronicDiseaseQueryServiceImpl(
         val sql =
             """
             SELECT
-                table1.chronic_disease_id,
-                table2.disease_name
+                cd.chronic_disease_id,
+                d.disease_name
             FROM
-                chronic_diseases AS table1
+                chronic_diseases AS cd
             INNER JOIN
-                diseases AS table2
+                diseases AS d
             ON
-                table1.disease_id = table2.disease_id
+                cd.disease_id = d.disease_id
             WHERE
-                table1.user_id = :userID
+                cd.user_id = :userID
             AND
-                table1.deleted_at IS NULL
+                cd.deleted_at IS NULL
             """.trimIndent()
         val params = MapSqlParameterSource().addValue("userID", userID.value)
         val chronicDiseases =

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/chronic_disease/ChronicDiseaseQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/chronic_disease/ChronicDiseaseQueryService.kt
@@ -1,0 +1,54 @@
+package com.unicorn.api.query_service.chronic_disease
+
+import com.unicorn.api.domain.user.UserID
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Service
+import java.util.*
+
+interface ChronicDiseaseQueryService {
+    fun get(userID: UserID): ChronicDiseaseResult
+}
+
+@Service
+class ChronicDiseaseQueryServiceImpl(
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate,
+) : ChronicDiseaseQueryService {
+    override fun get(userID: UserID): ChronicDiseaseResult {
+        //language=postgresql
+        val sql =
+            """
+            SELECT
+                table1.chronic_disease_id,
+                table2.disease_name
+            FROM
+                chronic_diseases AS table1
+            INNER JOIN
+                diseases AS table2
+            ON
+                table1.disease_id = table2.disease_id
+            WHERE
+                table1.user_id = :userID
+            AND
+                table1.deleted_at IS NULL
+            """.trimIndent()
+        val params = MapSqlParameterSource().addValue("userID", userID.value)
+        val chronicDiseases =
+            namedParameterJdbcTemplate.query(sql, params) { rs, _ ->
+                ChronicDiseaseDto(
+                    chronicDiseaseID = UUID.fromString(rs.getString("chronic_disease_id")),
+                    diseaseName = rs.getString("disease_name"),
+                )
+            }
+        return ChronicDiseaseResult(chronicDiseases)
+    }
+}
+
+data class ChronicDiseaseDto(
+    val chronicDiseaseID: UUID,
+    val diseaseName: String,
+)
+
+data class ChronicDiseaseResult(
+    val data: List<ChronicDiseaseDto>,
+)

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseDeleteTest.kt
@@ -36,7 +36,7 @@ class ChronicDiseaseDeleteTest {
 
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                MockMvcRequestBuilders.delete("/chronic_diseases/$chronicDiseaseID")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)
@@ -54,7 +54,7 @@ class ChronicDiseaseDeleteTest {
 
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                MockMvcRequestBuilders.delete("/chronic_diseases/$chronicDiseaseID")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)
@@ -83,7 +83,7 @@ class ChronicDiseaseDeleteTest {
 
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                MockMvcRequestBuilders.delete("/chronic_diseases/$chronicDiseaseID")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)
@@ -112,7 +112,7 @@ class ChronicDiseaseDeleteTest {
 
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.delete("/chronic_disease/$chronicDiseaseID")
+                MockMvcRequestBuilders.delete("/chronic_diseases/$chronicDiseaseID")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseGetTest.kt
@@ -31,7 +31,7 @@ class ChronicDiseaseGetTest {
         val userID = "test"
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.get("/chronic_disease")
+                MockMvcRequestBuilders.get("/chronic_diseases")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)
@@ -62,7 +62,7 @@ class ChronicDiseaseGetTest {
         val userID = "notfound"
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.get("/chronic_disease")
+                MockMvcRequestBuilders.get("/chronic_diseases")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseGetTest.kt
@@ -48,6 +48,14 @@ class ChronicDiseaseGetTest {
                         {
                             "chronicDiseaseID": "f47ac10b-58cc-4372-a567-0e02b2c3d470",
                             "diseaseName": "風邪"
+                        },
+                        {
+                            "chronicDiseaseID": "f47ac10b-58cc-4372-a567-0e02b2c3d469",
+                            "diseaseName": "インフルエンザ"
+                        },
+                        {
+                            "chronicDiseaseID": "f47ac10b-58cc-4372-a567-0e02b2c3d468",
+                            "diseaseName": "花粉症"
                         }
                     ]
                 }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseGetTest.kt
@@ -1,0 +1,85 @@
+package com.unicorn.api.controller.chronic_disease
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/disease/Insert_Disease_Data.sql")
+@Sql("/db/chronic_disease/Insert_Chronic_Disease_Data.sql")
+class ChronicDiseaseGetTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `return 200 when get chronic_disease`() {
+        val userID = "test"
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.get("/chronic_disease")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    ),
+            )
+        result.andExpect(status().isOk)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "data": [
+                        {
+                            "chronicDiseaseID": "f47ac10b-58cc-4372-a567-0e02b2c3d470",
+                            "diseaseName": "風邪"
+                        }
+                    ]
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+
+    @Test
+    fun `return 400 when user not found`() {
+        val userID = "notfound"
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.get("/chronic_disease")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    ),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseasePostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseasePostTest.kt
@@ -44,7 +44,7 @@ class ChronicDiseasePostTest {
 
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.post("/chronic_disease")
+                MockMvcRequestBuilders.post("/chronic_diseases")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)
@@ -77,7 +77,7 @@ class ChronicDiseasePostTest {
 
         val result =
             mockMvc.perform(
-                MockMvcRequestBuilders.post("/chronic_disease")
+                MockMvcRequestBuilders.post("/chronic_diseases")
                     .headers(
                         HttpHeaders().apply {
                             add("X-UID", userID)

--- a/api-server/src/test/resources/db/chronic_disease/Insert_Chronic_Disease_Data.sql
+++ b/api-server/src/test/resources/db/chronic_disease/Insert_Chronic_Disease_Data.sql
@@ -11,6 +11,18 @@ INSERT INTO chronic_diseases (
     NOW(),
     null
 ), (
+    'f47ac10b-58cc-4372-a567-0e02b2c3d469',
+    'test',
+    2,
+    NOW(),
+    null
+), (
+    'f47ac10b-58cc-4372-a567-0e02b2c3d468',
+    'test',
+    3,
+    NOW(),
+    null
+), (
     'f47ac10b-58cc-4372-a567-0e02b2c3d471',
     'test',
     2,


### PR DESCRIPTION
## 概要
- 持病情報を一括取得するAPIを実装する
- 持病情報が適切に取得できているかどうかを確認するテストを行う

## 変更点
- ControllerにGetを追加
- QueryServiceを追加
- GETのテストを行うテストファイルを追加

## 確認したこと
- テストが通ることを確認
- ローカル環境で一覧取得できたことを確認

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
