### PR TITLE
[TSK-235] Medicineをcreate_atでソート

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/medicine/MedicineQueryService.kt
@@ -51,6 +51,7 @@ class MedicineQueryServiceImpl(
                 user_id = :userID
                 AND medicines.deleted_at IS NULL
             GROUP BY medicines.medicine_id
+            ORDER BY medicines.created_at
             """.trimIndent()
 
         val sqlParams =


### PR DESCRIPTION
## 概要
medicneをGETする際、create_atを基準に古いものから新しいものへとソートできるようにする

## 変更点
- MedicineQuerySerivce.ktのgetMedicines()メソッドにSQL文を追加

## 確認したこと
- created_atが異なるテストデータをmedicinesテーブルに用意し、medicineをGETした際にcreate_atが古いものから順に並んでいることを確認
