### PR TITLE
fix: Calls API で、CallReservation が見つからなかった場合に 空の配列を返すよう修正

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
@@ -9,6 +9,7 @@ import com.unicorn.api.domain.call.CallReservationID
 import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.call.CallQueryService
+import com.unicorn.api.query_service.call.CallResult
 import com.unicorn.api.query_service.doctor.DoctorQueryService
 import com.unicorn.api.query_service.user.UserQueryService
 import org.springframework.http.ResponseEntity
@@ -48,7 +49,7 @@ class CallController(
 
         val result =
             callQueryService.get(DoctorID(doctorID), UserID(uid))
-                ?: return ResponseEntity.status(400).body(ResponseError("No call reservations found"))
+                ?: return ResponseEntity.ok(CallResult(emptyList()))
 
         return ResponseEntity.ok(result)
     }
@@ -63,7 +64,7 @@ class CallController(
 
         val result =
             callQueryService.getByDoctorID(DoctorID(doctorID))
-                ?: return ResponseEntity.status(400).body(ResponseError("No call reservations found"))
+                ?: return ResponseEntity.ok(CallResult(emptyList()))
 
         return ResponseEntity.ok(result)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
@@ -9,7 +9,6 @@ import com.unicorn.api.domain.call.CallReservationID
 import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.call.CallQueryService
-import com.unicorn.api.query_service.call.CallResult
 import com.unicorn.api.query_service.doctor.DoctorQueryService
 import com.unicorn.api.query_service.user.UserQueryService
 import org.springframework.http.ResponseEntity
@@ -49,7 +48,6 @@ class CallController(
 
         val result =
             callQueryService.get(DoctorID(doctorID), UserID(uid))
-                ?: return ResponseEntity.ok(CallResult(emptyList()))
 
         return ResponseEntity.ok(result)
     }
@@ -64,7 +62,6 @@ class CallController(
 
         val result =
             callQueryService.getByDoctorID(DoctorID(doctorID))
-                ?: return ResponseEntity.ok(CallResult(emptyList()))
 
         return ResponseEntity.ok(result)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/call/CallQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/call/CallQueryService.kt
@@ -14,9 +14,9 @@ interface CallQueryService {
     fun get(
         doctorID: DoctorID,
         userID: UserID,
-    ): CallResult?
+    ): CallResult
 
-    fun getByDoctorID(doctorID: DoctorID): CallResult?
+    fun getByDoctorID(doctorID: DoctorID): CallResult
 }
 
 @Service
@@ -26,7 +26,7 @@ class CallQueryServiceImpl(
     override fun get(
         doctorID: DoctorID,
         userID: UserID,
-    ): CallResult? {
+    ): CallResult {
         //language=postgresql
         val sql =
             """
@@ -57,13 +57,10 @@ class CallQueryServiceImpl(
                     callEndTime = rs.getObject("call_end_time", OffsetDateTime::class.java),
                 )
             }
-        if (calls.isEmpty()) {
-            return null
-        }
         return CallResult(calls)
     }
 
-    override fun getByDoctorID(doctorID: DoctorID): CallResult? {
+    override fun getByDoctorID(doctorID: DoctorID): CallResult {
         //language=postgresql
         val sql =
             """
@@ -93,9 +90,6 @@ class CallQueryServiceImpl(
                     callEndTime = rs.getObject("call_end_time", OffsetDateTime::class.java),
                 )
             }
-        if (calls.isEmpty()) {
-            return null
-        }
         return CallResult(calls)
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallGetTest.kt
@@ -142,7 +142,7 @@ class CallGetTest {
     }
 
     @Test
-    fun `should return 400 when call reservation not found`() {
+    fun `should return 200 when call reservation not found`() {
         val userID = "12345"
         val doctorID = "doctor"
 
@@ -156,6 +156,16 @@ class CallGetTest {
                     .param("doctorID", doctorID)
                     .param("userID", userID),
             )
-        result.andExpect(status().isBadRequest)
+        result.andExpect(status().isOk)
+        result.andExpect(
+            content().json(
+                """
+                {
+                    "data": []
+                }
+                """.trimIndent(),
+                false,
+            ),
+        )
     }
 }


### PR DESCRIPTION
## 概要
CallReservation が見つからなかった場合に 空の配列を返すよう修正

## 変更点
- CallController を修正
- テストの修正

## 確認したこと
- テストが通ること

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
