### PR TITLE
通話予約で、開始時間と終了時間が被った際にエラーにならないよう修正

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/call/CallRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/call/CallRepository.kt
@@ -125,10 +125,11 @@ class CallRepositoryImpl(private val namedParameterJdbcTemplate: NamedParameterJ
             SELECT COUNT(*) 
             FROM call_reservations
             WHERE doctor_id = :doctorID
-              AND deleted_at IS NULL
-              AND (
-                (call_start_time, call_end_time) OVERLAPS (:callStartTime, :callEndTime)
-              )
+            AND deleted_at IS NULL
+            AND (
+                call_start_time < :callEndTime
+                AND call_end_time > :callStartTime
+            )
             """.trimIndent()
 
         val sqlParams =

--- a/api-server/src/main/kotlin/com/unicorn/api/query_service/call/CallQueryService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/query_service/call/CallQueryService.kt
@@ -39,7 +39,7 @@ class CallQueryServiceImpl(
             FROM call_reservations
             WHERE doctor_id = :doctor_id
             AND user_id = :user_id
-            AND call_start_time >= CURRENT_TIMESTAMP
+            AND call_end_time >= CURRENT_TIMESTAMP
             AND deleted_at IS NULL
             ORDER BY call_start_time ASC
             """.trimIndent()
@@ -72,8 +72,8 @@ class CallQueryServiceImpl(
                 call_end_time
             FROM call_reservations
             WHERE doctor_id = :doctor_id
-            AND call_start_time >= CURRENT_TIMESTAMP
-            AND call_start_time <= CURRENT_TIMESTAMP + INTERVAL '1 YEAR'
+            AND call_end_time >= CURRENT_TIMESTAMP
+            AND call_end_time <= CURRENT_TIMESTAMP + INTERVAL '1 YEAR'
             AND deleted_at IS NULL
             ORDER BY call_start_time ASC
             """.trimIndent()

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPostTest.kt
@@ -45,8 +45,8 @@ class CallPostTest {
             CallPostRequest(
                 userID = userID,
                 doctorID = "doctor",
-                callStartTime = OffsetDateTime.parse("2024-10-12T15:00:00+09:00"),
-                callEndTime = OffsetDateTime.parse("2024-10-12T15:30:00+09:00"),
+                callStartTime = OffsetDateTime.parse("2021-01-01T10:30:00+09:00"),
+                callEndTime = OffsetDateTime.parse("2021-01-01T11:00:00+09:00"),
             )
 
         val result =
@@ -68,8 +68,8 @@ class CallPostTest {
                 {
                     "doctorID": "${call.doctorID}",
                     "userID": "$userID",
-                    "callStartTime": "2024-10-12T15:00:00+09:00",
-                    "callEndTime": "2024-10-12T15:30:00+09:00"
+                    "callStartTime": "2021-01-01T10:30:00+09:00",
+                    "callEndTime": "2021-01-01T11:00:00+09:00"
                 }
                 """.trimIndent(),
             ),

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPutTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPutTest.kt
@@ -46,8 +46,8 @@ class CallPutTest {
             CallPostRequest(
                 userID = userID,
                 doctorID = "doctor",
-                callStartTime = OffsetDateTime.parse("2024-10-12T15:00:00+09:00"),
-                callEndTime = OffsetDateTime.parse("2024-10-12T15:30:00+09:00"),
+                callStartTime = OffsetDateTime.parse("2021-01-01T10:30:00+09:00"),
+                callEndTime = OffsetDateTime.parse("2021-01-01T11:00:00+09:00"),
             )
 
         val result =
@@ -70,8 +70,8 @@ class CallPutTest {
                     "callReservationID": "$callReservationID",
                     "doctorID": "${call.doctorID}",
                     "userID": "$userID",
-                    "callStartTime": "2024-10-12T15:00:00+09:00",
-                    "callEndTime": "2024-10-12T15:30:00+09:00"
+                    "callStartTime": "2021-01-01T10:30:00+09:00",
+                    "callEndTime": "2021-01-01T11:00:00+09:00"
                 }
                 """.trimIndent(),
             ),

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/call/CallRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/call/CallRepositoryTest.kt
@@ -139,8 +139,8 @@ class CallRepositoryTest {
     @Test
     fun `should return false when no overlapping call reservation`() {
         // 既存の予約と被らない新しいコール予約を作成
-        val newCallStartTime = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 10, 0, 0), ZoneOffset.of("+09:00"))
-        val newCallEndTime = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 10, 30, 0), ZoneOffset.of("+09:00"))
+        val newCallStartTime = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 9, 30, 0), ZoneOffset.of("+09:00"))
+        val newCallEndTime = OffsetDateTime.of(LocalDateTime.of(2021, 1, 1, 10, 0, 0), ZoneOffset.of("+09:00"))
         val doctorID = "12345"
 
         val isOverlapping = callRepository.isOverlapping(newCallStartTime, newCallEndTime, doctorID)


### PR DESCRIPTION
## 概要
通話予約で、開始時間と終了時間が被った際にエラーにならないよう修正
通話予約情報取得の際に、絞り込みの条件を開始時間から終了時間に修正

## 変更点
- リポジトリ層の isOverlapping を修正
- クエリサービス層の get と getByDoctorID を修正
- 各種テストの変更

## 確認したこと
- テストが通ること