### PR TITLE
fix: call API で現在時刻より前の予約をできないように修正

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/domain/call/service/CallDomainService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/domain/call/service/CallDomainService.kt
@@ -3,6 +3,7 @@ package com.unicorn.api.domain.call.service
 import com.unicorn.api.controller.call.CallPostRequest
 import com.unicorn.api.domain.call_support.CallSupport
 import org.springframework.stereotype.Service
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 @Service
@@ -13,6 +14,14 @@ class CallDomainService {
         callPostRequest: CallPostRequest,
         doctorCallSupport: CallSupport,
     ) {
+        // 現在時刻を JST (UTC+9) で OffsetDateTime 型で取得
+        val currentJstTime = OffsetDateTime.now(jstOffset)
+
+        // callStartTime が現在時刻より前でないことを確認
+        require(!callPostRequest.callStartTime.isBefore(currentJstTime)) {
+            "The call start time cannot be in the past"
+        }
+
         // callStartTime と callEndTime を JST (UTC+9) で LocalTime に変換
         val callStartTimeJst = callPostRequest.callStartTime.withOffsetSameInstant(jstOffset).toLocalTime()
         val callEndTimeJst = callPostRequest.callEndTime.withOffsetSameInstant(jstOffset).toLocalTime()

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPostTest.kt
@@ -45,8 +45,8 @@ class CallPostTest {
             CallPostRequest(
                 userID = userID,
                 doctorID = "doctor",
-                callStartTime = OffsetDateTime.parse("2021-01-01T10:30:00+09:00"),
-                callEndTime = OffsetDateTime.parse("2021-01-01T11:00:00+09:00"),
+                callStartTime = OffsetDateTime.parse("2026-11-01T10:30:00+09:00"),
+                callEndTime = OffsetDateTime.parse("2026-11-01T11:00:00+09:00"),
             )
 
         val result =
@@ -68,8 +68,8 @@ class CallPostTest {
                 {
                     "doctorID": "${call.doctorID}",
                     "userID": "$userID",
-                    "callStartTime": "2021-01-01T10:30:00+09:00",
-                    "callEndTime": "2021-01-01T11:00:00+09:00"
+                    "callStartTime": "2026-11-01T10:30:00+09:00",
+                    "callEndTime": "2026-11-01T11:00:00+09:00"
                 }
                 """.trimIndent(),
             ),

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPutTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallPutTest.kt
@@ -46,8 +46,8 @@ class CallPutTest {
             CallPostRequest(
                 userID = userID,
                 doctorID = "doctor",
-                callStartTime = OffsetDateTime.parse("2021-01-01T10:30:00+09:00"),
-                callEndTime = OffsetDateTime.parse("2021-01-01T11:00:00+09:00"),
+                callStartTime = OffsetDateTime.parse("2026-11-01T10:30:00+09:00"),
+                callEndTime = OffsetDateTime.parse("2026-11-01T11:00:00+09:00"),
             )
 
         val result =
@@ -70,8 +70,8 @@ class CallPutTest {
                     "callReservationID": "$callReservationID",
                     "doctorID": "${call.doctorID}",
                     "userID": "$userID",
-                    "callStartTime": "2021-01-01T10:30:00+09:00",
-                    "callEndTime": "2021-01-01T11:00:00+09:00"
+                    "callStartTime": "2026-11-01T10:30:00+09:00",
+                    "callEndTime": "2026-11-01T11:00:00+09:00"
                 }
                 """.trimIndent(),
             ),

--- a/api-server/src/test/kotlin/com/unicorn/api/domain/call/service/CallDomainServiceTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/domain/call/service/CallDomainServiceTest.kt
@@ -36,8 +36,8 @@ class CallDomainServiceTest {
             CallPostRequest(
                 userID = "test",
                 doctorID = "doctor",
-                callStartTime = OffsetDateTime.parse("2024-10-12T15:00:00+09:00"),
-                callEndTime = OffsetDateTime.parse("2024-10-12T15:30:00+09:00"),
+                callStartTime = OffsetDateTime.parse("2025-10-12T15:00:00+09:00"),
+                callEndTime = OffsetDateTime.parse("2025-10-12T15:30:00+09:00"),
             )
 
         // サポート時間内なので、例外はスローされない


### PR DESCRIPTION
## 概要
call API で現在時刻より前の予約をできないように修正

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- ドメインサービス層を修正
- 各種テストの修正

## 確認したこと
- テストが通ること

## リリース時に確認すること
- 【重要】2026-11-01 以降テストが落ちます。アプリのリリースを続ける場合はテストをコメントアウトしてください。
