### PR TITLE
ユーザーのfcm_token_idをdoctorが取得できるようにAPIを追加

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/account/AccountController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/account/AccountController.kt
@@ -6,16 +6,13 @@ import com.unicorn.api.application_service.account.UpdateAccountService
 import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.account.Account
 import com.unicorn.api.domain.account.UID
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.query_service.account.AccountDto
 import com.unicorn.api.query_service.account.AccountQueryService
+import com.unicorn.api.query_service.doctor.DoctorQueryService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.*
 
 @Controller
 class AccountController(
@@ -23,6 +20,7 @@ class AccountController(
     private val accountQueryService: AccountQueryService,
     private val deleteAccountService: DeleteAccountService,
     private val updateAccountService: UpdateAccountService,
+    private val doctorQueryService: DoctorQueryService,
 ) {
     @PostMapping("/accounts")
     fun save(
@@ -56,6 +54,25 @@ class AccountController(
             return ResponseEntity.ok(result)
         } catch (e: Exception) {
             return ResponseEntity.internalServerError().build()
+        }
+    }
+
+    @GetMapping("/accounts/{accountUid}")
+    fun get(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable accountUid: String,
+    ): ResponseEntity<*> {
+        try {
+            doctorQueryService.getOrNullBy(DoctorID(uid))
+                ?: return ResponseEntity.badRequest().body(ResponseError("account is not doctor"))
+
+            val result =
+                accountQueryService.getOrNullBy(accountUid)
+                    ?: return ResponseEntity.badRequest().body(ResponseError("account is not found"))
+
+            return ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("internal server error"))
         }
     }
 

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/account/AccountGetTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/account/AccountGetTest.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.controller.account
 
 import com.unicorn.api.query_service.account.AccountDto
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -19,6 +20,12 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @Sql("/db/account/Insert_Account_Data.sql")
 @Sql("/db/account/Insert_Deleted_Account_Data.sql")
+@Sql("/db/hospital/Insert_Hospital_Data.sql")
+@Sql("/db/department/Insert_Department_Data.sql")
+@Sql("/db/doctor/Insert_Doctor_Data.sql")
+@Sql("/db/doctor_department/Insert_Doctor_Department_Data.sql")
+@Sql("/db/chat_support/Insert_Chat_Support_Data.sql")
+@Sql("/db/call_support/Insert_Call_Support_Data.sql")
 class AccountGetTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -72,5 +79,77 @@ class AccountGetTest {
             )
 
         result.andExpect(status().isNotFound)
+    }
+
+    @Nested
+    inner class GetByUID {
+        @Test
+        fun `should return 200 when account is found`() {
+            val accountDto =
+                AccountDto(
+                    uid = "test",
+                    role = "user",
+                    fcmTokenId = "fcm_token_id",
+                )
+
+            val result =
+                mockMvc.perform(
+                    MockMvcRequestBuilders.get("/accounts/${accountDto.uid}")
+                        .header("X-UID", "doctor"),
+                )
+
+            result.andExpect(status().isOk)
+            result.andExpect(
+                content().json(
+                    """
+                    {
+                        "uid": "${accountDto.uid}",
+                        "role": "${accountDto.role}",
+                        "fcmTokenId": "${accountDto.fcmTokenId}"
+                    }
+                    """.trimIndent(),
+                ),
+            )
+        }
+
+        @Test
+        fun `should return 400 when account is not doctor`() {
+            val result =
+                mockMvc.perform(
+                    MockMvcRequestBuilders.get("/accounts/test")
+                        .header("X-UID", "test"),
+                )
+
+            result.andExpect(status().isBadRequest)
+            result.andExpect(
+                content().json(
+                    """
+                    {
+                        "errorType": "account is not doctor"
+                    }
+                    """.trimIndent(),
+                ),
+            )
+        }
+
+        @Test
+        fun `should return 400 when account is not found`() {
+            val result =
+                mockMvc.perform(
+                    MockMvcRequestBuilders.get("/accounts/invalid")
+                        .header("X-UID", "doctor"),
+                )
+
+            result.andExpect(status().isBadRequest)
+            result.andExpect(
+                content().json(
+                    """
+                    {
+                        "errorType": "account is not found"
+                    }
+                    """.trimIndent(),
+                ),
+            )
+        }
     }
 }


### PR DESCRIPTION
## 概要
https://www.notion.so/FCM_TOKEN_ID-7b859b8a574748cdbdbd2416a81aaa59?pvs=4

## 変更点
- API実装
- テスト記述

## 確認したこと
- テストが通ること

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
