### PR TITLE
[TSK-295] primaryDoctorの重複登録回避の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/primary_doctor/SavePrimaryDoctorService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/primary_doctor/SavePrimaryDoctorService.kt
@@ -34,13 +34,16 @@ class SavePrimaryDoctorServiceImpl(
         val doctor = doctorRepository.getOrNullBy(doctorID)
         requireNotNull(doctor) { "Doctor not found" }
 
-        val primaryDoctor =
+        val primaryDoctor = primaryDoctorRepository.getOrNullByDoctorIDAndUserID(doctorID, userID)
+        require(primaryDoctor == null) { "Primary doctor already exists" }
+
+        val createPrimaryDoctor =
             PrimaryDoctor.create(
                 userID = userID.value,
                 doctorID = doctorID.value,
             )
-        primaryDoctorRepository.store(primaryDoctor)
+        primaryDoctorRepository.store(createPrimaryDoctor)
 
-        return primaryDoctor
+        return createPrimaryDoctor
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorPostTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorPostTest.kt
@@ -39,9 +39,9 @@ class PrimaryDoctorPostTest {
     fun `should return 200 when create primary doctor`() {
         val primaryDoctorRequest =
             PrimaryDoctorRequest(
-                doctorID = "doctor",
+                doctorID = "doctor3",
             )
-        val userID = "test"
+        val userID = "testtest"
 
         val result =
             mockMvc.perform(
@@ -127,6 +127,39 @@ class PrimaryDoctorPostTest {
                 """
                 {
                     "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+
+    @Test
+    fun `should return 400 when already exists primary doctor`() {
+        val primaryDoctorRequest =
+            PrimaryDoctorRequest(
+                doctorID = "doctor",
+            )
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/primary_doctors")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(primaryDoctorRequest)),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "Primary doctor already exists"
                 }
                 """.trimIndent(),
                 true,


### PR DESCRIPTION
## 概要
primaryDoctorの登録時にすでに同じUserID・DoctorIDの組み合わせが登録されていた場合、badrequestを返す機能

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- SaveApplicationServiceを変更
- テストの追加

## 確認したこと
- テストが通ったこと

## リリース時に確認すること
- リリース作業時に確認することを記載してください。
