### PR TITLE
[TSK-297] 要請時に家族とかかりつけ医にメールを送信機能の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/RobotRequestService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/RobotRequestService.kt
@@ -9,6 +9,7 @@ import com.unicorn.api.infrastructure.account.AccountRepository
 import com.unicorn.api.infrastructure.emergency.EmergencyRepository
 import com.unicorn.api.infrastructure.robot.RobotRepository
 import com.unicorn.api.infrastructure.robot_support.RobotSupportRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -22,10 +23,10 @@ class RobotRequestServiceImpl(
     private val robotRepository: RobotRepository,
     private val robotSupportRepository: RobotSupportRepository,
     private val accountRepository: AccountRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : RobotRequestService {
     override fun request(emergency: Emergency): Pair<EmergencyUserStatus?, EmergencyRobotStatus?> {
         emergencyRepository.getOrNullBy(emergency.emergencyID) ?: return Pair(null, null)
-
         val robot = robotRepository.getWaitingOrNull()
         if (robot == null) {
             val waitingCount = emergencyRepository.getWaitingCount(emergency.emergencyID)
@@ -60,6 +61,8 @@ class RobotRequestServiceImpl(
         robotRepository.store(supportStatus)
 
         emergencyRepository.delete(emergency)
+
+        applicationEventPublisher.publishEvent(RobotDispatchedEvent(emergency))
 
         return Pair(emergencyUserStatus, emergencyRobotStatus)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/SendMailEmergencyService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/SendMailEmergencyService.kt
@@ -1,0 +1,64 @@
+package com.unicorn.api.application_service.emergency
+
+import com.unicorn.api.domain.emergency.Emergency
+import com.unicorn.api.infrastructure.doctor.DoctorRepository
+import com.unicorn.api.infrastructure.family_email.FamilyEmailRepository
+import com.unicorn.api.infrastructure.primary_doctor.PrimaryDoctorRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import com.unicorn.api.util.MailTransport
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+interface SendMailEmergencyService {
+    fun send(emergency: Emergency)
+}
+
+@Service
+class SendMailEmergencyServiceImpl(
+    private val userRepository: UserRepository,
+    private val familyEmailRepository: FamilyEmailRepository,
+    private val primaryDoctorRepository: PrimaryDoctorRepository,
+    private val doctorRepository: DoctorRepository,
+    private val mailTransport: MailTransport,
+) : SendMailEmergencyService {
+    @Async
+    override fun send(emergency: Emergency) {
+        val user = userRepository.getOrNullBy(emergency.userID) ?: return
+
+        val familyEmails = familyEmailRepository.getOrNullByUserID(emergency.userID)
+
+        val primaryDoctors = primaryDoctorRepository.getOrNullByUserID(emergency.userID)
+
+        if (familyEmails == null && primaryDoctors == null) return
+
+        val subject = "${user.lastName.value} ${user.firstName.value}さんの緊急要請"
+
+        val body =
+            //language=html
+            """
+            <html>
+            <head>
+            </head>
+            <body>
+            <h1>${user.lastName.value} ${user.firstName.value}さんの緊急要請</h1>
+            <p>${user.lastName.value} ${user.firstName.value}さんがunicornを緊急要請しました。</p>
+            </body>
+            </html>
+            """
+
+        if (familyEmails != null) {
+            familyEmails.map {
+                val email = it.email.value
+                mailTransport.send(email, subject, body)
+            }
+        }
+
+        if (primaryDoctors != null) {
+            primaryDoctors.map {
+                val doctor = doctorRepository.getOrNullBy(it.doctorID) ?: return
+                val email = doctor.email.value
+                mailTransport.send(email, subject, body)
+            }
+        }
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/SendMailEmergencyService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/SendMailEmergencyService.kt
@@ -29,8 +29,6 @@ class SendMailEmergencyServiceImpl(
 
         val primaryDoctors = primaryDoctorRepository.getOrNullByUserID(emergency.userID)
 
-        if (familyEmails == null && primaryDoctors == null) return
-
         val subject = "${user.lastName.value} ${user.firstName.value}さんの緊急要請"
 
         val body =
@@ -46,19 +44,15 @@ class SendMailEmergencyServiceImpl(
             </html>
             """
 
-        if (familyEmails != null) {
-            familyEmails.map {
-                val email = it.email.value
-                mailTransport.send(email, subject, body)
-            }
+        familyEmails.map {
+            val email = it.email.value
+            mailTransport.send(email, subject, body)
         }
 
-        if (primaryDoctors != null) {
-            primaryDoctors.map {
-                val doctor = doctorRepository.getOrNullBy(it.doctorID) ?: return
-                val email = doctor.email.value
-                mailTransport.send(email, subject, body)
-            }
+        primaryDoctors.map {
+            val doctor = doctorRepository.getOrNullBy(it.doctorID) ?: return
+            val email = doctor.email.value
+            mailTransport.send(email, subject, body)
         }
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/health_checkup/SendMailHealthCheckupService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/health_checkup/SendMailHealthCheckupService.kt
@@ -33,7 +33,6 @@ class SendMailHealthCheckupServiceImpl(
 
         val primaryDoctors =
             primaryDoctorRepository.getOrNullByUserID(healthCheckup.userID)
-                ?: return
 
         primaryDoctors.map {
             val doctor = doctorRepository.getOrNullBy(it.doctorID) ?: return

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/emergency/DispatchedEventListener.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/emergency/DispatchedEventListener.kt
@@ -1,0 +1,20 @@
+package com.unicorn.api.controller.emergency
+
+import com.unicorn.api.application_service.emergency.SendMailEmergencyService
+import com.unicorn.api.domain.emergency.RobotDispatchedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+interface DispatchedEventListener {
+    fun onSendMail(robotDispatchedEvent: RobotDispatchedEvent)
+}
+
+@Component
+class DispatchedEventListenerImpl(
+    private val sendMailEmergencyService: SendMailEmergencyService,
+) : DispatchedEventListener {
+    @EventListener
+    override fun onSendMail(robotDispatchedEvent: RobotDispatchedEvent) {
+        sendMailEmergencyService.send(robotDispatchedEvent.emergency)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/domain/emergency/RobotDispatchedEvent.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/domain/emergency/RobotDispatchedEvent.kt
@@ -1,0 +1,5 @@
+package com.unicorn.api.domain.emergency
+
+data class RobotDispatchedEvent(
+    val emergency: Emergency,
+)

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.family_email
 
 import com.unicorn.api.domain.family_email.*
+import com.unicorn.api.domain.user.UserID
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -10,6 +11,8 @@ interface FamilyEmailRepository {
     fun store(familyEmail: FamilyEmail): FamilyEmail
 
     fun getOrNullBy(familyEmailID: FamilyEmailID): FamilyEmail?
+
+    fun getOrNullByUserID(userID: UserID): List<FamilyEmail>?
 
     fun delete(familyEmail: FamilyEmail): Unit
 }
@@ -94,6 +97,39 @@ class FamilyEmailRepositoryImpl(
                 iconImageUrl = rs.getString("icon_image_url"),
             )
         }.singleOrNull()
+    }
+
+    override fun getOrNullByUserID(userID: UserID): List<FamilyEmail>? {
+        // language=postgresql
+        val sql =
+            """
+            SELECT
+                family_email_id,
+                user_id,
+                email,
+                family_first_name,
+                family_last_name,
+                icon_image_url
+            FROM family_emails
+            WHERE user_id = :userID
+            AND deleted_at IS NULL
+            """.trimIndent()
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", userID.value)
+        return namedParameterJdbcTemplate.query(
+            sql,
+            sqlParams,
+        ) { rs, _ ->
+            FamilyEmail.fromStore(
+                familyEmailID = UUID.fromString(rs.getString("family_email_id")),
+                userID = rs.getString("user_id"),
+                email = rs.getString("email"),
+                firstName = rs.getString("family_first_name"),
+                lastName = rs.getString("family_last_name"),
+                iconImageUrl = rs.getString("icon_image_url"),
+            )
+        }
     }
 
     override fun delete(familyEmail: FamilyEmail) {

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
@@ -12,7 +12,7 @@ interface FamilyEmailRepository {
 
     fun getOrNullBy(familyEmailID: FamilyEmailID): FamilyEmail?
 
-    fun getOrNullByUserID(userID: UserID): List<FamilyEmail>?
+    fun getOrNullByUserID(userID: UserID): List<FamilyEmail>
 
     fun delete(familyEmail: FamilyEmail): Unit
 }
@@ -99,7 +99,7 @@ class FamilyEmailRepositoryImpl(
         }.singleOrNull()
     }
 
-    override fun getOrNullByUserID(userID: UserID): List<FamilyEmail>? {
+    override fun getOrNullByUserID(userID: UserID): List<FamilyEmail> {
         // language=postgresql
         val sql =
             """

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepository.kt
@@ -13,7 +13,7 @@ interface PrimaryDoctorRepository {
 
     fun getOrNullBy(primaryDoctorID: PrimaryDoctorID): PrimaryDoctor?
 
-    fun getOrNullByUserID(userID: UserID): List<PrimaryDoctor>?
+    fun getOrNullByUserID(userID: UserID): List<PrimaryDoctor>
 
     fun getOrNullByDoctorIDAndUserID(
         doctorID: DoctorID,
@@ -82,7 +82,7 @@ class PrimaryDoctorRepositoryImpl(
         }.singleOrNull()
     }
 
-    override fun getOrNullByUserID(userID: UserID): List<PrimaryDoctor>? {
+    override fun getOrNullByUserID(userID: UserID): List<PrimaryDoctor> {
         // language=postgresql
         val sql =
             """

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
@@ -158,10 +158,19 @@ class FamilyEmailRepositoryTest {
         val familyEmails = familyEmailRepository.getOrNullByUserID(userID)
 
         assertNotNull(familyEmails)
-        assertEquals(1, familyEmails!!.size)
+        assertEquals(1, familyEmails.size)
         assertEquals("sample@sample.com", familyEmails[0].email.value)
         assertEquals("太郎", familyEmails[0].firstName.value)
         assertEquals("山田", familyEmails[0].lastName.value)
         assertEquals("https://example.com", familyEmails[0].iconImageUrl?.value)
+    }
+
+    @Test
+    fun `should not find family emails by not found userID`() {
+        val userID = UserID("notFound")
+
+        val familyEmails = familyEmailRepository.getOrNullByUserID(userID)
+
+        assertEquals(0, familyEmails.size)
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.family_email
 
 import com.unicorn.api.domain.family_email.*
+import com.unicorn.api.domain.user.UserID
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -148,5 +149,19 @@ class FamilyEmailRepositoryTest {
         familyEmailRepository.delete(familyEmail)
         val deletedFamilyEmail = familyEmailRepository.getOrNullBy(familyEmail.familyEmailID)
         assertNull(deletedFamilyEmail)
+    }
+
+    @Test
+    fun `should find family emails by userID`() {
+        val userID = UserID("test")
+
+        val familyEmails = familyEmailRepository.getOrNullByUserID(userID)
+
+        assertNotNull(familyEmails)
+        assertEquals(1, familyEmails!!.size)
+        assertEquals("sample@sample.com", familyEmails[0].email.value)
+        assertEquals("太郎", familyEmails[0].firstName.value)
+        assertEquals("山田", familyEmails[0].lastName.value)
+        assertEquals("https://example.com", familyEmails[0].iconImageUrl?.value)
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepositoryTest.kt
@@ -92,7 +92,7 @@ class PrimaryDoctorRepositoryTest {
         val foundPrimaryDoctors = primaryDoctorRepository.getOrNullByUserID(userID)
 
         assertNotNull(foundPrimaryDoctors)
-        assertEquals(2, foundPrimaryDoctors!!.size)
+        assertEquals(2, foundPrimaryDoctors.size)
         assertEquals("test", foundPrimaryDoctors[0].userID.value)
         assertEquals("doctor", foundPrimaryDoctors[0].doctorID.value)
         assertEquals("test", foundPrimaryDoctors[1].userID.value)
@@ -114,7 +114,7 @@ class PrimaryDoctorRepositoryTest {
 
         val foundPrimaryDoctors = primaryDoctorRepository.getOrNullByUserID(userID)
 
-        assertEquals(0, foundPrimaryDoctors!!.size)
+        assertEquals(0, foundPrimaryDoctors.size)
     }
 
     @Test


### PR DESCRIPTION
## 概要
unicorn要請時に家族メールで登録されている人と、かかりつけ医で登録されている人すべてにメールを送信する機能

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- FamilyEmailRepositoryにUserIDで取得する関数追加
- RobotRequestServiceにApplicationEventPublisher追加
- EmergencyDomainにRobotDispatchEvent追加
- EmergencyControllerにRobotDispathedEventListener追加
- ApplicationServiceにSendMailEmergencyService追加
- FamilyEmailRecositoryのテスト追加

## 確認したこと
- テストが通ったこと
- ローカル環境でメールが送信されたこと
![IMG_8446](https://github.com/user-attachments/assets/95e7f41b-0ab2-486f-8539-d3460e1e6f19)

## リリース時に確認すること
- メールの件名と本文
