### PR TITLE
userID に対応した call reservation の全削除機能の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/call/DeleteCallService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/call/DeleteCallService.kt
@@ -11,6 +11,8 @@ interface DeleteCallService {
         callReservationID: CallReservationID,
         userID: UserID,
     )
+
+    fun deleteByUserID(userID: UserID)
 }
 
 @Service
@@ -29,5 +31,12 @@ class DeleteCallServiceImpl(
         requireNotNull(callReservation) { "Call reservation not found" }
 
         callRepository.delete(callReservation)
+    }
+
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        callRepository.deleteByUserID(userID)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
@@ -142,6 +142,21 @@ class CallController(
             return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
+
+    @DeleteMapping("/users/{userID}/calls")
+    fun deleteByUserID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteCallService.deleteByUserID(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
 }
 
 data class CallPostRequest(

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/call/CallRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/call/CallRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.call
 
 import com.unicorn.api.domain.call.Call
 import com.unicorn.api.domain.call.CallReservationID
+import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.util.toJST
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -21,6 +22,8 @@ interface CallRepository {
         callEndTime: OffsetDateTime,
         doctorID: String,
     ): Boolean
+
+    fun deleteByUserID(userID: UserID)
 }
 
 @Repository
@@ -140,5 +143,21 @@ class CallRepositoryImpl(private val namedParameterJdbcTemplate: NamedParameterJ
 
         val count = namedParameterJdbcTemplate.queryForObject(sql, sqlParams, Int::class.java)
         return count != null && count > 0
+    }
+
+    override fun deleteByUserID(userID: UserID) {
+        val sql =
+            """
+            UPDATE call_reservations
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", userID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallDeleteByUserIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallDeleteByUserIDTest.kt
@@ -1,0 +1,67 @@
+package com.unicorn.api.controller.call
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@Sql("/db/primary_doctor/Insert_Parent_Account_Data.sql")
+@Sql("/db/primary_doctor/Insert_User_Data.sql")
+@Sql("/db/primary_doctor/Insert_Hospital_Data.sql")
+@Sql("/db/primary_doctor/Insert_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Department_Data.sql")
+@Sql("/db/call_support/Insert_Call_Support_Data.sql")
+@Sql("/db/call/Insert_New_Call_Data.sql")
+class CallDeleteByUserIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when call reservation is deleted`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/calls")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "notfound"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/calls")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}


### PR DESCRIPTION
## 概要
userID に対応した call reservation の全削除機能の実装
（"/users/{userID}/calls"）

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- CallController, DeleteCallService, CallRepository に追記
- テストの追加

## 確認したこと
- テストが通ること

## リリース時に確認すること
- call reservation の削除を行ってから user を削除してください。
