### PR TITLE
MedicineのPUT APIにおけるReminderTimeのフォーマット

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -1,5 +1,6 @@
 package com.unicorn.api.controller.medicine
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.unicorn.api.application_service.medicine.DeleteMedicineService
 import com.unicorn.api.application_service.medicine.SaveMedicineService
 import com.unicorn.api.application_service.medicine.UpdateMedicineService
@@ -125,6 +126,7 @@ data class MedicinePutRequest(
 
 data class ReminderRequest(
     val reminderID: UUID,
+    @JsonFormat(pattern = "HH:mm")
     val reminderTime: LocalTime,
     val reminderDayOfWeek: List<String>,
 )

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinePutTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicinePutTest.kt
@@ -78,7 +78,7 @@ class MedicinePutTest {
                     "reminders": [
                         {
                             "reminderID": "${medicine.reminders[0].reminderID}",
-                            "reminderTime": "${medicine.reminders[0].reminderTime}:00",
+                            "reminderTime": "${medicine.reminders[0].reminderTime}",
                             "reminderDayOfWeek": [
                                 "${medicine.reminders[0].reminderDayOfWeek[0]}",
                                 "${medicine.reminders[0].reminderDayOfWeek[1]}"


### PR DESCRIPTION
## 概要
PUT ResponseがHH:mm:ssだと都合が悪いというフィードバックをもらったので修正

## 変更点

- Jsonformatを設置
- テスト修正

## 確認したこと
- テストが通ること
