### PR TITLE
User 削除時に、userID を利用した各データの削除機能の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/chat/DeleteChatService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/chat/DeleteChatService.kt
@@ -1,0 +1,23 @@
+package com.unicorn.api.application_service.chat
+
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.chat.ChatRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteChatService {
+    fun deleteBy(userID: UserID)
+}
+
+@Service
+class DeleteChatServiceImpl(
+    private val userRepository: UserRepository,
+    private val chatRepository: ChatRepository,
+) : DeleteChatService {
+    override fun deleteBy(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        chatRepository.deleteByUser(user)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/chronic_disease/DeleteChronicDiseaseService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/chronic_disease/DeleteChronicDiseaseService.kt
@@ -11,6 +11,8 @@ interface DeleteChronicDiseaseService {
         userID: UserID,
         chronicDiseaseID: ChronicDiseaseID,
     ): Unit
+
+    fun deleteBy(userID: UserID)
 }
 
 @Service
@@ -29,5 +31,12 @@ class DeleteChronicDiseaseServiceImpl(
         requireNotNull(chronicDisease) { "Chronic disease not found" }
 
         chronicDiseaseRepository.delete(chronicDisease)
+    }
+
+    override fun deleteBy(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        chronicDiseaseRepository.deleteByUser(user)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/DeleteEmergencyService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/emergency/DeleteEmergencyService.kt
@@ -1,0 +1,23 @@
+package com.unicorn.api.application_service.emergency
+
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.emergency.EmergencyRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteEmergencyService {
+    fun deleteByUserID(userID: UserID)
+}
+
+@Service
+class DeleteEmergencyServiceImpl(
+    private val userRepository: UserRepository,
+    private val emergencyRepository: EmergencyRepository,
+) : DeleteEmergencyService {
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        emergencyRepository.deleteByUser(user)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/DeleteFamilyEmailService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/family_email/DeleteFamilyEmailService.kt
@@ -11,6 +11,8 @@ interface DeleteFamilyEmailService {
         familyEmailID: FamilyEmailID,
         userID: UserID,
     ): Unit
+
+    fun deleteByUserID(userID: UserID)
 }
 
 @Service
@@ -29,5 +31,12 @@ class DeleteFamilyEmailServiceImpl(
         requireNotNull(familyEmail) { "Family email not found" }
 
         familyEmailRepository.delete(familyEmail)
+    }
+
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        familyEmailRepository.deleteByUser(user)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/health_checkup/DeleteHealthCheckupService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/health_checkup/DeleteHealthCheckupService.kt
@@ -11,6 +11,8 @@ interface DeleteHealthCheckupService {
         userID: UserID,
         healthCheckupID: HealthCheckupID,
     ): Unit
+
+    fun deleteByUserID(userID: UserID)
 }
 
 @Service
@@ -29,5 +31,12 @@ class DeleteHealthCheckupServiceImpl(
         requireNotNull(healthCheckup) { "Health checkup not found" }
 
         healthCheckupRepository.delete(healthCheckup)
+    }
+
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        healthCheckupRepository.deleteByUser(user)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/medicine/DeleteMedicineService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/medicine/DeleteMedicineService.kt
@@ -13,6 +13,8 @@ interface DeleteMedicineService {
         userID: UserID,
         medicineID: MedicineID,
     ): Unit
+
+    fun deleteByUserID(userID: UserID)
 }
 
 @Service
@@ -40,5 +42,14 @@ class DeleteMedicineServiceImpl(
 
         medicineRepository.delete(medicine)
         medicineRemindersRepository.delete(medicineReminders)
+    }
+
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        medicineRepository.deleteByUser(user)
+
+        medicineRemindersRepository.deleteByUser(user)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/message/DeleteMessageService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/message/DeleteMessageService.kt
@@ -3,9 +3,11 @@ package com.unicorn.api.application_service.message
 import com.unicorn.api.domain.account.UID
 import com.unicorn.api.domain.chat.ChatID
 import com.unicorn.api.domain.message.MessageID
+import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.infrastructure.account.AccountRepository
 import com.unicorn.api.infrastructure.chat.ChatRepository
 import com.unicorn.api.infrastructure.message.MessageRepository
+import com.unicorn.api.infrastructure.user.UserRepository
 import org.springframework.stereotype.Service
 
 interface DeleteMessageService {
@@ -14,11 +16,14 @@ interface DeleteMessageService {
         chatID: ChatID,
         messageID: MessageID,
     )
+
+    fun deleteBy(userID: UserID)
 }
 
 @Service
 class DeleteMessageServiceImpl(
     private val accountRepository: AccountRepository,
+    private val userRepository: UserRepository,
     private val chatRepository: ChatRepository,
     private val messageRepository: MessageRepository,
 ) : DeleteMessageService {
@@ -38,5 +43,12 @@ class DeleteMessageServiceImpl(
         require(message.isSender(account.uid)) { "You are not the sender of this message" }
 
         messageRepository.delete(message)
+    }
+
+    override fun deleteBy(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        messageRepository.deleteByUser(user)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/notification/DeleteNotificationService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/notification/DeleteNotificationService.kt
@@ -1,0 +1,26 @@
+package com.unicorn.api.application_service.notification
+
+import com.unicorn.api.domain.user.UserID
+import com.unicorn.api.infrastructure.notification.NotificationRepository
+import com.unicorn.api.infrastructure.user.UserRepository
+import org.springframework.stereotype.Service
+
+interface DeleteNotificationService {
+    fun deleteByUserID(userID: UserID)
+}
+
+@Service
+class DeleteNotificationServiceImpl(
+    private val userRepository: UserRepository,
+    private val notificationRepository: NotificationRepository,
+) : DeleteNotificationService {
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        val notification = notificationRepository.getOrNullBy(userID)
+        requireNotNull(notification) { "Notification not found" }
+
+        notificationRepository.deleteByUser(user)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/primary_doctor/DeletePrimaryDoctorService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/primary_doctor/DeletePrimaryDoctorService.kt
@@ -12,6 +12,8 @@ interface DeletePrimaryDoctorService {
         userID: UserID,
         doctorID: DoctorID,
     ): Unit
+
+    fun deleteByUserID(userID: UserID)
 }
 
 @Service
@@ -34,5 +36,12 @@ class DeletePrimaryDoctorServiceImpl(
         requireNotNull(primaryDoctor) { "Primary doctor not found" }
 
         primaryDoctorRepository.delete(primaryDoctor)
+    }
+
+    override fun deleteByUserID(userID: UserID) {
+        val user = userRepository.getOrNullBy(userID)
+        requireNotNull(user) { "User not found" }
+
+        primaryDoctorRepository.deleteByUser(user)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chat/ChatController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chat/ChatController.kt
@@ -1,12 +1,16 @@
 package com.unicorn.api.controller.chat
 
+import com.unicorn.api.application_service.chat.DeleteChatService
 import com.unicorn.api.application_service.chat.SaveChatService
 import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.account.UID
+import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.chat.ChatQueryService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 class ChatController(
     private val chatQueryService: ChatQueryService,
     private val saveChatService: SaveChatService,
+    private val deleteChatService: DeleteChatService,
 ) {
     @PostMapping("/chats")
     fun postChat(
@@ -38,6 +43,21 @@ class ChatController(
         try {
             val result = chatQueryService.getBy(UID(uid))
             return ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/users/{userID}/chats")
+    fun deleteByUserID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteChatService.deleteBy(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
         } catch (e: Exception) {
             return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseController.kt
@@ -61,6 +61,21 @@ class ChronicDiseaseController(
             return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
         }
     }
+
+    @DeleteMapping("/users/{userID}/chronic_diseases")
+    fun deleteByUserID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteChronicDiseaseService.deleteBy(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
 }
 
 data class ChronicDiseasePostRequest(

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/emergency/EmergencyController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/emergency/EmergencyController.kt
@@ -1,7 +1,9 @@
 package com.unicorn.api.controller.emergency
 
+import com.unicorn.api.application_service.emergency.DeleteEmergencyService
 import com.unicorn.api.application_service.emergency.SaveEmergencyService
 import com.unicorn.api.controller.api_response.ResponseError
+import com.unicorn.api.domain.user.UserID
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
@@ -10,6 +12,7 @@ import java.util.*
 @Controller
 class EmergencyController(
     private val saveEmergencyService: SaveEmergencyService,
+    private val deleteEmergencyService: DeleteEmergencyService,
 ) {
     @PostMapping("/unicorn/emergency")
     fun post(
@@ -19,6 +22,21 @@ class EmergencyController(
         try {
             val result = saveEmergencyService.save(emergencyPostRequest)
             return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/users/{userID}/emergency")
+    fun deleteBy(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteEmergencyService.deleteByUserID(UserID(userID))
+            return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
         } catch (e: Exception) {

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/family_email/FamilyEmailController.kt
@@ -81,6 +81,21 @@ class FamilyEmailController(
             return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
+
+    @DeleteMapping("/users/{userID}/family_emails")
+    fun deleteBy(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteFamilyEmailService.deleteByUserID(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
 }
 
 data class FamilyEmailPostRequest(

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupController.kt
@@ -102,6 +102,21 @@ class HealthCheckupController(
             return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
         }
     }
+
+    @DeleteMapping("/users/{userID}/health_checkups")
+    fun deleteBy(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteHealthCheckupService.deleteByUserID(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
 }
 
 data class HealthCheckupPostRequest(

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/medicine/MedicineController.kt
@@ -28,11 +28,7 @@ class MedicineController(
         @RequestHeader("X-UID") uid: String,
     ): ResponseEntity<*> {
         return try {
-            val user = userQueryService.getOrNullBy(uid)
-
-            if (user == null) {
-                return ResponseEntity.status(400).body("User not found")
-            }
+            val user = userQueryService.getOrNullBy(uid) ?: return ResponseEntity.status(400).body("User not found")
 
             val result = medicineQueryService.getMedicines(uid)
             ResponseEntity.ok(result)
@@ -98,6 +94,21 @@ class MedicineController(
     ): ResponseEntity<Any> {
         try {
             deleteMedicineService.delete(UserID(uid), MedicineID(medicineID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/users/{userID}/medicines")
+    fun deleteByUserID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteMedicineService.deleteByUserID(UserID(userID))
             return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/message/MessageController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/message/MessageController.kt
@@ -6,6 +6,7 @@ import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.account.UID
 import com.unicorn.api.domain.chat.ChatID
 import com.unicorn.api.domain.message.MessageID
+import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.message.MessageQueryService
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
@@ -47,6 +48,21 @@ class MessageController(
     ): ResponseEntity<Any> {
         try {
             deleteMessageService.delete(UID(uid), ChatID(chatID), MessageID(messageID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/users/{userID}/messages")
+    fun deleteMessageByUserID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteMessageService.deleteBy(UserID(userID))
             return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/notification/NotificationController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/notification/NotificationController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*
 class NotificationController(
     private val saveNotificationService: SaveNotificationService,
     private val updateNotificationService: UpdateNotificationService,
+    private val deleteNotificationService: DeleteNotificationService,
     private val notificationQueryService: NotificationQueryService,
     private val userQueryService: UserQueryService,
 ) {
@@ -59,6 +60,21 @@ class NotificationController(
         try {
             val result = updateNotificationService.update(UserID(userID), notificationPutRequest)
             return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/users/{userID}/notification")
+    fun deleteBy(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteNotificationService.deleteByUserID(UserID(userID))
+            return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
         } catch (e: Exception) {

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorController.kt
@@ -79,6 +79,21 @@ class PrimaryDoctorController(
             return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
         }
     }
+
+    @DeleteMapping("/users/{userID}/primary_doctors")
+    fun deleteBy(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable userID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deletePrimaryDoctorService.deleteByUserID(UserID(uid))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
 }
 
 data class PrimaryDoctorRequest(

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/chat/ChatRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/chat/ChatRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.chat
 
 import com.unicorn.api.domain.chat.Chat
 import com.unicorn.api.domain.chat.ChatID
+import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -13,6 +14,8 @@ interface ChatRepository {
     fun getOrNullBy(chatID: ChatID): Chat?
 
     fun delete(chat: Chat)
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -81,6 +84,23 @@ class ChatRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("chatID", chat.chatID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE chats
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/chronic_disease/ChronicDiseaseRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/chronic_disease/ChronicDiseaseRepository.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.chronic_disease
 
 import com.unicorn.api.domain.chronic_disease.*
+import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -12,6 +13,8 @@ interface ChronicDiseaseRepository {
     fun getOrNullBy(chronicDiseaseID: ChronicDiseaseID): ChronicDisease?
 
     fun delete(chronicDisease: ChronicDisease)
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -86,6 +89,23 @@ class ChronicDiseaseRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("chronicDiseaseID", chronicDisease.chronicDiseaseID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE chronic_diseases
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/emergency/EmergencyRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/emergency/EmergencyRepository.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.emergency
 
 import com.unicorn.api.domain.emergency.*
+import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -16,6 +17,8 @@ interface EmergencyRepository {
     fun getWaitingCount(emergencyID: EmergencyID): Int?
 
     fun delete(emergency: Emergency)
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -144,6 +147,23 @@ class EmergencyRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("emergencyID", emergency.emergencyID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE emergency_queue
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepository.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.family_email
 
 import com.unicorn.api.domain.family_email.*
+import com.unicorn.api.domain.user.User
 import com.unicorn.api.domain.user.UserID
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -15,6 +16,8 @@ interface FamilyEmailRepository {
     fun getOrNullByUserID(userID: UserID): List<FamilyEmail>
 
     fun delete(familyEmail: FamilyEmail): Unit
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -143,6 +146,21 @@ class FamilyEmailRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("familyEmailID", familyEmail.familyEmailID.value)
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE family_emails
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/health_checkup/HealthCheckupRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/health_checkup/HealthCheckupRepository.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.health_checkup
 
 import com.unicorn.api.domain.health_checkup.*
+import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -12,6 +13,8 @@ interface HealthCheckupRepository {
     fun getOrNullBy(healthCheckupID: HealthCheckupID): HealthCheckup?
 
     fun delete(healthCheckup: HealthCheckup)
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -111,6 +114,23 @@ class HealthCheckupRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("healthCheckupID", healthCheckup.healthCheckupID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE health_checkups
+            SET deleted_at = NOW()
+            WHERE checkuped_user_id = :userID
+            AND deleted_at IS NULL
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/medicine/MedicineRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/medicine/MedicineRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.medicine
 
 import com.unicorn.api.domain.medicine.Medicine
 import com.unicorn.api.domain.medicine.MedicineID
+import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -13,6 +14,8 @@ interface MedicineRepository {
     fun getOrNullBy(medicineID: MedicineID): Medicine?
 
     fun delete(medicine: Medicine): Unit
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -108,6 +111,23 @@ class MedicineRepositoryImpl(private val namedParameterJdbcTemplate: NamedParame
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("medicineID", medicine.medicineID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE medicines
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/message/MessageRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/message/MessageRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.message
 
 import com.unicorn.api.domain.message.Message
 import com.unicorn.api.domain.message.MessageID
+import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -14,6 +15,8 @@ interface MessageRepository {
     fun getOrNullBy(messageID: MessageID): Message?
 
     fun delete(message: Message)
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -101,6 +104,23 @@ class MessageRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("messageID", message.messageID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE messages
+            SET deleted_at = NOW()
+            WHERE sender_id = :userID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.primary_doctor
 
 import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.primary_doctor.*
+import com.unicorn.api.domain.user.User
 import com.unicorn.api.domain.user.UserID
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -21,6 +22,8 @@ interface PrimaryDoctorRepository {
     ): PrimaryDoctor?
 
     fun delete(primaryDoctor: PrimaryDoctor)
+
+    fun deleteByUser(user: User)
 }
 
 @Repository
@@ -153,6 +156,23 @@ class PrimaryDoctorRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("primaryDoctorID", primaryDoctor.primaryDoctorID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByUser(user: User) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE primary_doctors
+            SET deleted_at = NOW()
+            WHERE user_id = :userID
+            AND deleted_at IS NULL
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("userID", user.userID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chat/ChatDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chat/ChatDeleteTest.kt
@@ -1,0 +1,57 @@
+package com.unicorn.api.controller.chat
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@AutoConfigureMockMvc
+@Sql("/db/account/Insert_Account_Data.sql")
+@Sql("/db/hospital/Insert_Hospital_Data.sql")
+@Sql("/db/department/Insert_Department_Data.sql")
+@Sql("/db/doctor/Insert_Doctor_Data.sql")
+@Sql("/db/doctor_department/Insert_Doctor_Department_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/chat/Insert_Chat_Data.sql")
+@Sql("/db/message/Insert_Message_Data.sql")
+class ChatDeleteTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete chat`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/chats")
+                    .header("X-UID", userID),
+            )
+
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when delete chat with invalid userID`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/chats")
+                    .header("X-UID", userID),
+            )
+
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseDeleteByUserIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chronic_disease/ChronicDiseaseDeleteByUserIDTest.kt
@@ -1,0 +1,76 @@
+package com.unicorn.api.controller.chronic_disease
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/disease/Insert_Disease_Data.sql")
+@Sql("/db/chronic_disease/Insert_Chronic_Disease_Data.sql")
+class ChronicDiseaseDeleteByUserIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete success`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/chronic_diseases")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "notfound"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/chronic_diseases")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/emergency/EmergencyDeleteByUserTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/emergency/EmergencyDeleteByUserTest.kt
@@ -1,0 +1,68 @@
+package com.unicorn.api.controller.emergency
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/emergency/Insert_Emergency_Data.sql")
+class EmergencyDeleteByUserTest {
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete success`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/emergency")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/emergency")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailDeleteByUserIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/family_email/FamilyEmailDeleteByUserIDTest.kt
@@ -1,0 +1,64 @@
+package com.unicorn.api.application_service.family_email
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/user/Insert_Deleted_User_Data.sql")
+@Sql("/db/family_email/Insert_FamilyEmail_Data.sql")
+class FamilyEmailDeleteByUserIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when family email is deleted`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/family_emails")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/family_emails")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupDeleteByUserIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/health_checkup/HealthCheckupDeleteByUserIDTest.kt
@@ -1,0 +1,76 @@
+package com.unicorn.api.controller.health_checkup
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/user/Insert_Deleted_User_Data.sql")
+@Sql("/db/health_checkup/Insert_HealthCheckup_Data.sql")
+class HealthCheckupDeleteByUserIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete health checkup`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/health_checkups")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/health_checkups")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicineDeleteByUserIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/medicine/MedicineDeleteByUserIDTest.kt
@@ -1,0 +1,61 @@
+package com.unicorn.api.controller.medicine
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/medicine/Insert_Medicine_Data.sql")
+@Sql("/db/medicine_reminder/Insert_Medicine_Reminder_Data.sql")
+class MedicineDeleteByUserIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when medicine is deleted by userID`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/medicines").headers(
+                    HttpHeaders().apply {
+                        add("X-UID", userID)
+                    },
+                )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user ID is invalid`() {
+        val userID = "invalid-id"
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/users/$userID/medicines").headers(
+                HttpHeaders().apply {
+                    add("X-UID", userID)
+                },
+            )
+                .contentType(MediaType.APPLICATION_JSON),
+        )
+            .andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/message/MessageDeleteByUserIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/message/MessageDeleteByUserIDTest.kt
@@ -1,0 +1,57 @@
+package com.unicorn.api.controller.message
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@AutoConfigureMockMvc
+@Sql("/db/account/Insert_Account_Data.sql")
+@Sql("/db/hospital/Insert_Hospital_Data.sql")
+@Sql("/db/department/Insert_Department_Data.sql")
+@Sql("/db/doctor/Insert_Doctor_Data.sql")
+@Sql("/db/doctor_department/Insert_Doctor_Department_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/chat/Insert_Chat_Data.sql")
+@Sql("/db/message/Insert_Message_Data.sql")
+class MessageDeleteByUserIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete message`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/messages")
+                    .header("X-UID", userID),
+            )
+
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when delete message with invalid userID`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/messages")
+                    .header("X-UID", userID),
+            )
+
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/notification/NotificationDeleteTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/notification/NotificationDeleteTest.kt
@@ -1,0 +1,85 @@
+package com.unicorn.api.controller.notification
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/user/Insert_Parent_Account_Data.sql")
+@Sql("/db/notification/Insert_User_Data.sql")
+@Sql("/db/notification/Insert_Notification_Data.sql")
+class NotificationDeleteTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should return 204 when delete notification`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/notification")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/notification")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when notification not found`() {
+        val userID = "12345"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/notification")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorDeleteByUserTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorDeleteByUserTest.kt
@@ -1,0 +1,79 @@
+package com.unicorn.api.controller.primary_doctor
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/primary_doctor/Insert_Parent_Account_Data.sql")
+@Sql("/db/primary_doctor/Insert_User_Data.sql")
+@Sql("/db/primary_doctor/Insert_Hospital_Data.sql")
+@Sql("/db/primary_doctor/Insert_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_PrimaryDoctor_Data.sql")
+class PrimaryDoctorDeleteByUserTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 200 when delete primary doctor`() {
+        val userID = "test"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/primary_doctors")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when user not found`() {
+        val userID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/users/$userID/primary_doctors")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", userID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "User not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
@@ -76,7 +76,7 @@ class FamilyEmailRepositoryTest {
             AND deleted_at IS NULL
             """.trimIndent()
 
-        val sqlParams = MapSqlParameterSource().addValue("userID", userID)
+        val sqlParams = MapSqlParameterSource().addValue("userID", userID.value)
 
         return namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
             FamilyEmail.fromStore(
@@ -227,7 +227,7 @@ class FamilyEmailRepositoryTest {
 
         familyEmailRepository.deleteByUser(user)
 
-        val deletedFamilyEmail = familyEmailRepository.getOrNullByUserID(user.userID)
+        val deletedFamilyEmail = findFamilyEmailByUserID(user.userID)
         assertEquals(0, deletedFamilyEmail.size)
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/family_email/FamilyEmailRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.family_email
 
 import com.unicorn.api.domain.family_email.*
+import com.unicorn.api.domain.user.User
 import com.unicorn.api.domain.user.UserID
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -12,6 +13,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.util.*
 
 @TestPropertySource(locations = ["classpath:application-test.properties"])
@@ -56,6 +58,36 @@ class FamilyEmailRepositoryTest {
                 iconImageUrl = rs.getString("icon_image_url"),
             )
         }.singleOrNull()
+    }
+
+    private fun findFamilyEmailByUserID(userID: UserID): List<FamilyEmail> {
+        //language=postgresql
+        val sql =
+            """
+            SELECT
+                family_email_id,
+                user_id,
+                email,
+                family_first_name,
+                family_last_name,
+                icon_image_url
+            FROM family_emails
+            WHERE user_id = :userID
+            AND deleted_at IS NULL
+            """.trimIndent()
+
+        val sqlParams = MapSqlParameterSource().addValue("userID", userID)
+
+        return namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
+            FamilyEmail.fromStore(
+                familyEmailID = UUID.fromString(rs.getString("family_email_id")),
+                userID = rs.getString("user_id"),
+                email = rs.getString("email"),
+                firstName = rs.getString("family_first_name"),
+                lastName = rs.getString("family_last_name"),
+                iconImageUrl = rs.getString("icon_image_url"),
+            )
+        }
     }
 
     @Test
@@ -172,5 +204,30 @@ class FamilyEmailRepositoryTest {
         val familyEmails = familyEmailRepository.getOrNullByUserID(userID)
 
         assertEquals(0, familyEmails.size)
+    }
+
+    @Test
+    fun `should delete family email by user`() {
+        val user =
+            User.fromStore(
+                userID = "test",
+                firstName = "test",
+                lastName = "test",
+                email = "sample@test.com",
+                birthDate = LocalDate.of(1990, 1, 1),
+                gender = "male",
+                address = "test",
+                postalCode = "0000000",
+                phoneNumber = "00000000000",
+                iconImageUrl = "https://example.com",
+                bodyHeight = 170.4,
+                bodyWeight = 60.4,
+                occupation = "test",
+            )
+
+        familyEmailRepository.deleteByUser(user)
+
+        val deletedFamilyEmail = familyEmailRepository.getOrNullByUserID(user.userID)
+        assertEquals(0, deletedFamilyEmail.size)
     }
 }

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/notification/NotificationRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/notification/NotificationRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.unicorn.api.infrastructure.notification
 
 import com.unicorn.api.domain.notification.*
+import com.unicorn.api.domain.user.User
 import com.unicorn.api.domain.user.UserID
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -12,6 +13,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.util.*
 
 @TestPropertySource(locations = ["classpath:application-test.properties"])
@@ -116,5 +118,34 @@ class NotificationRepositoryTest {
         val foundNotification = notificationRepository.getOrNullBy(userID)
 
         assertNull(foundNotification)
+    }
+
+    @Test
+    fun `should delete notification by user`() {
+        val user =
+            User.fromStore(
+                userID = "test",
+                firstName = "test",
+                lastName = "test",
+                email = "sample@test.com",
+                birthDate = LocalDate.of(1990, 1, 1),
+                gender = "male",
+                address = "test",
+                postalCode = "0000000",
+                phoneNumber = "00000000000",
+                iconImageUrl = "https://example.com",
+                bodyHeight = 170.4,
+                bodyWeight = 60.4,
+                occupation = "test",
+            )
+
+        notificationRepository.deleteByUser(user)
+
+        val deletedNotification = findNotificationBy(user.userID)
+        assertNotNull(deletedNotification)
+        assertEquals(user.userID.value, deletedNotification!!.userID.value)
+        assertEquals(false, deletedNotification.isMedicineReminder.value)
+        assertEquals(false, deletedNotification.isRegularHealthCheckup.value)
+        assertEquals(false, deletedNotification.isHospitalNews.value)
     }
 }


### PR DESCRIPTION
## 概要
User 削除時に、userID を利用した各データの削除機能の実装
https://www.notion.so/Account-16d3ff32f06e4481ada5bb288feba697?pvs=4

## 変更点
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- messages 削除機能の実装
- chats 削除機能の実装
- medicines, medicine_reminders 削除機能の実装
- chronic_diseases 削除機能の実装
- primary_doctors 削除機能の実装
- health_checkups 削除機能の実装
- family_emails 削除機能の実装
- emergency 削除機能の実装
- user_notifications 削除機能の実装

## 確認したこと
- テストが通ること

## リリース時に確認すること
- User 削除前に API をたたいてください。削除後はエラーになります。
