### PR TITLE
doctorID を使用した 削除機能の実装

### DIFF
--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/call/DeleteCallService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/call/DeleteCallService.kt
@@ -1,8 +1,10 @@
 package com.unicorn.api.application_service.call
 
 import com.unicorn.api.domain.call.CallReservationID
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.infrastructure.call.CallRepository
+import com.unicorn.api.infrastructure.doctor.DoctorRepository
 import com.unicorn.api.infrastructure.user.UserRepository
 import org.springframework.stereotype.Service
 
@@ -13,11 +15,14 @@ interface DeleteCallService {
     )
 
     fun deleteByUserID(userID: UserID)
+
+    fun deleteByDoctorID(doctorID: DoctorID)
 }
 
 @Service
 class DeleteCallServiceImpl(
     private val userRepository: UserRepository,
+    private val doctorRepository: DoctorRepository,
     private val callRepository: CallRepository,
 ) : DeleteCallService {
     override fun delete(
@@ -38,5 +43,12 @@ class DeleteCallServiceImpl(
         requireNotNull(user) { "User not found" }
 
         callRepository.deleteByUserID(userID)
+    }
+
+    override fun deleteByDoctorID(doctorID: DoctorID) {
+        val doctor = doctorRepository.getOrNullBy(doctorID)
+        requireNotNull(doctor) { "Doctor not found" }
+
+        callRepository.deleteByDoctor(doctor)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/chat/DeleteChatService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/chat/DeleteChatService.kt
@@ -1,17 +1,22 @@
 package com.unicorn.api.application_service.chat
 
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.infrastructure.chat.ChatRepository
+import com.unicorn.api.infrastructure.doctor.DoctorRepository
 import com.unicorn.api.infrastructure.user.UserRepository
 import org.springframework.stereotype.Service
 
 interface DeleteChatService {
     fun deleteBy(userID: UserID)
+
+    fun deleteByDoctorID(doctorID: DoctorID)
 }
 
 @Service
 class DeleteChatServiceImpl(
     private val userRepository: UserRepository,
+    private val doctorRepository: DoctorRepository,
     private val chatRepository: ChatRepository,
 ) : DeleteChatService {
     override fun deleteBy(userID: UserID) {
@@ -19,5 +24,12 @@ class DeleteChatServiceImpl(
         requireNotNull(user) { "User not found" }
 
         chatRepository.deleteByUser(user)
+    }
+
+    override fun deleteByDoctorID(doctorID: DoctorID) {
+        val doctor = doctorRepository.getOrNullBy(doctorID)
+        requireNotNull(doctor) { "Doctor not found" }
+
+        chatRepository.deleteByDoctor(doctor)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/doctor_department/DeleteDoctorDepartmentsService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/doctor_department/DeleteDoctorDepartmentsService.kt
@@ -1,0 +1,23 @@
+package com.unicorn.api.application_service.doctor_department
+
+import com.unicorn.api.domain.doctor.DoctorID
+import com.unicorn.api.infrastructure.department.DepartmentRepository
+import com.unicorn.api.infrastructure.doctor.DoctorRepository
+import org.springframework.stereotype.Service
+
+interface DeleteDoctorDepartmentsService {
+    fun deleteByDoctorID(doctorID: DoctorID)
+}
+
+@Service
+class DeleteDoctorDepartmentsServiceImpl(
+    private val doctorRepository: DoctorRepository,
+    private val departmentRepository: DepartmentRepository,
+) : DeleteDoctorDepartmentsService {
+    override fun deleteByDoctorID(doctorID: DoctorID) {
+        val doctor = doctorRepository.getOrNullBy(doctorID)
+        requireNotNull(doctor) { "Doctor not found" }
+
+        departmentRepository.deleteByDoctor(doctor)
+    }
+}

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/message/DeleteMessageService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/message/DeleteMessageService.kt
@@ -2,10 +2,12 @@ package com.unicorn.api.application_service.message
 
 import com.unicorn.api.domain.account.UID
 import com.unicorn.api.domain.chat.ChatID
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.message.MessageID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.infrastructure.account.AccountRepository
 import com.unicorn.api.infrastructure.chat.ChatRepository
+import com.unicorn.api.infrastructure.doctor.DoctorRepository
 import com.unicorn.api.infrastructure.message.MessageRepository
 import com.unicorn.api.infrastructure.user.UserRepository
 import org.springframework.stereotype.Service
@@ -18,12 +20,15 @@ interface DeleteMessageService {
     )
 
     fun deleteBy(userID: UserID)
+
+    fun deleteByDoctorID(doctorID: DoctorID)
 }
 
 @Service
 class DeleteMessageServiceImpl(
     private val accountRepository: AccountRepository,
     private val userRepository: UserRepository,
+    private val doctorRepository: DoctorRepository,
     private val chatRepository: ChatRepository,
     private val messageRepository: MessageRepository,
 ) : DeleteMessageService {
@@ -50,5 +55,12 @@ class DeleteMessageServiceImpl(
         requireNotNull(user) { "User not found" }
 
         messageRepository.deleteByUser(user)
+    }
+
+    override fun deleteByDoctorID(doctorID: DoctorID) {
+        val doctor = doctorRepository.getOrNullBy(doctorID)
+        requireNotNull(doctor) { "Doctor not found" }
+
+        messageRepository.deleteByDoctor(doctor)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/application_service/primary_doctor/DeletePrimaryDoctorService.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/application_service/primary_doctor/DeletePrimaryDoctorService.kt
@@ -14,6 +14,8 @@ interface DeletePrimaryDoctorService {
     ): Unit
 
     fun deleteByUserID(userID: UserID)
+
+    fun deleteByDoctorID(doctorID: DoctorID)
 }
 
 @Service
@@ -43,5 +45,12 @@ class DeletePrimaryDoctorServiceImpl(
         requireNotNull(user) { "User not found" }
 
         primaryDoctorRepository.deleteByUser(user)
+    }
+
+    override fun deleteByDoctorID(doctorID: DoctorID) {
+        val doctor = doctorRepository.getOrNullBy(doctorID)
+        requireNotNull(doctor) { "Doctor not found" }
+
+        primaryDoctorRepository.deleteByDoctor(doctor)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/call/CallController.kt
@@ -157,6 +157,21 @@ class CallController(
             return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
+
+    @DeleteMapping("/doctors/{doctorID}/calls")
+    fun deleteByDoctorID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable doctorID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteCallService.deleteByDoctorID(DoctorID(doctorID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
 }
 
 data class CallPostRequest(

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/chat/ChatController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/chat/ChatController.kt
@@ -4,6 +4,7 @@ import com.unicorn.api.application_service.chat.DeleteChatService
 import com.unicorn.api.application_service.chat.SaveChatService
 import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.account.UID
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.chat.ChatQueryService
 import org.springframework.http.ResponseEntity
@@ -55,6 +56,21 @@ class ChatController(
     ): ResponseEntity<Any> {
         try {
             deleteChatService.deleteBy(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/doctors/{doctorID}/chats")
+    fun deleteByDoctorID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable doctorID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteChatService.deleteByDoctorID(DoctorID(doctorID))
             return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/departments/DepartmentsController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/departments/DepartmentsController.kt
@@ -1,15 +1,17 @@
 package com.unicorn.api.controller.departments
 
+import com.unicorn.api.application_service.doctor_department.DeleteDoctorDepartmentsService
+import com.unicorn.api.controller.api_response.ResponseError
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.query_service.departments.DepartmentsQueryService
 import com.unicorn.api.query_service.departments.DepartmentsResult
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class DepartmentsController(
     private val departmentsQueryService: DepartmentsQueryService,
+    private val deleteDoctorDepartmentsService: DeleteDoctorDepartmentsService,
 ) {
     @GetMapping("/departments")
     fun getDepartments(
@@ -20,6 +22,21 @@ class DepartmentsController(
             return ResponseEntity.ok(result)
         } catch (e: Exception) {
             return ResponseEntity.status(500).build()
+        }
+    }
+
+    @DeleteMapping("/doctors/{doctorID}/doctor_departments")
+    fun deleteByDoctorID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable doctorID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteDoctorDepartmentsService.deleteByDoctorID(DoctorID(doctorID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(400).body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
         }
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/message/MessageController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/message/MessageController.kt
@@ -5,6 +5,7 @@ import com.unicorn.api.application_service.message.SaveMessageService
 import com.unicorn.api.controller.api_response.ResponseError
 import com.unicorn.api.domain.account.UID
 import com.unicorn.api.domain.chat.ChatID
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.message.MessageID
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.query_service.message.MessageQueryService
@@ -63,6 +64,21 @@ class MessageController(
     ): ResponseEntity<Any> {
         try {
             deleteMessageService.deleteBy(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.status(500).body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/doctors/{doctorID}/messages")
+    fun deleteMessageByDoctorID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable doctorID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deleteMessageService.deleteByDoctorID(DoctorID(doctorID))
             return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))

--- a/api-server/src/main/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorController.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorController.kt
@@ -86,7 +86,22 @@ class PrimaryDoctorController(
         @PathVariable userID: String,
     ): ResponseEntity<Any> {
         try {
-            deletePrimaryDoctorService.deleteByUserID(UserID(uid))
+            deletePrimaryDoctorService.deleteByUserID(UserID(userID))
+            return ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))
+        } catch (e: Exception) {
+            return ResponseEntity.internalServerError().body(ResponseError("Internal Server Error"))
+        }
+    }
+
+    @DeleteMapping("/doctors/{doctorID}/primary_doctors")
+    fun deleteByDoctorID(
+        @RequestHeader("X-UID") uid: String,
+        @PathVariable doctorID: String,
+    ): ResponseEntity<Any> {
+        try {
+            deletePrimaryDoctorService.deleteByDoctorID(DoctorID(doctorID))
             return ResponseEntity.noContent().build()
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.badRequest().body(ResponseError(e.message ?: "Bad Request"))

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/call/CallRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/call/CallRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.call
 
 import com.unicorn.api.domain.call.Call
 import com.unicorn.api.domain.call.CallReservationID
+import com.unicorn.api.domain.doctor.Doctor
 import com.unicorn.api.domain.user.UserID
 import com.unicorn.api.util.toJST
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
@@ -24,6 +25,8 @@ interface CallRepository {
     ): Boolean
 
     fun deleteByUserID(userID: UserID)
+
+    fun deleteByDoctor(doctor: Doctor)
 }
 
 @Repository
@@ -157,6 +160,22 @@ class CallRepositoryImpl(private val namedParameterJdbcTemplate: NamedParameterJ
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("userID", userID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByDoctor(doctor: Doctor) {
+        val sql =
+            """
+            UPDATE call_reservations
+            SET deleted_at = NOW()
+            WHERE doctor_id = :doctorID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("doctorID", doctor.doctorID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/chat/ChatRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/chat/ChatRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.chat
 
 import com.unicorn.api.domain.chat.Chat
 import com.unicorn.api.domain.chat.ChatID
+import com.unicorn.api.domain.doctor.Doctor
 import com.unicorn.api.domain.user.User
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -16,6 +17,8 @@ interface ChatRepository {
     fun delete(chat: Chat)
 
     fun deleteByUser(user: User)
+
+    fun deleteByDoctor(doctor: Doctor)
 }
 
 @Repository
@@ -101,6 +104,23 @@ class ChatRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTempl
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("userID", user.userID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByDoctor(doctor: Doctor) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE chats
+            SET deleted_at = NOW()
+            WHERE doctor_id = :doctorID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("doctorID", doctor.doctorID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/department/DepartmentRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/department/DepartmentRepository.kt
@@ -2,6 +2,7 @@ package com.unicorn.api.infrastructure.department
 
 import com.unicorn.api.domain.department.Department
 import com.unicorn.api.domain.department.DepartmentID
+import com.unicorn.api.domain.doctor.Doctor
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -11,6 +12,8 @@ interface DepartmentRepository {
     fun getOrNullBy(departmentID: DepartmentID): Department?
 
     fun findByDepartmentIDs(departmentIDs: List<DepartmentID>): List<Department?>
+
+    fun deleteByDoctor(doctor: Doctor)
 }
 
 @Repository
@@ -62,5 +65,22 @@ class DepartmentRepositoryImpl(
         return departmentIDs.map { departmentID ->
             result.find { it.departmentID == departmentID }
         }
+    }
+
+    override fun deleteByDoctor(doctor: Doctor) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE doctor_departments
+            SET deleted_at = NOW()
+            WHERE doctor_id = :doctorID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("doctorID", doctor.doctorID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
     }
 }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/message/MessageRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/message/MessageRepository.kt
@@ -1,5 +1,6 @@
 package com.unicorn.api.infrastructure.message
 
+import com.unicorn.api.domain.doctor.Doctor
 import com.unicorn.api.domain.message.Message
 import com.unicorn.api.domain.message.MessageID
 import com.unicorn.api.domain.user.User
@@ -17,6 +18,8 @@ interface MessageRepository {
     fun delete(message: Message)
 
     fun deleteByUser(user: User)
+
+    fun deleteByDoctor(doctor: Doctor)
 }
 
 @Repository
@@ -121,6 +124,23 @@ class MessageRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("userID", user.userID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByDoctor(doctor: Doctor) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE messages
+            SET deleted_at = NOW()
+            WHERE sender_id = :doctorID
+            AND deleted_at IS NULL;
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("doctorID", doctor.doctorID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/main/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepository.kt
+++ b/api-server/src/main/kotlin/com/unicorn/api/infrastructure/primary_doctor/PrimaryDoctorRepository.kt
@@ -1,5 +1,6 @@
 package com.unicorn.api.infrastructure.primary_doctor
 
+import com.unicorn.api.domain.doctor.Doctor
 import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.primary_doctor.*
 import com.unicorn.api.domain.user.User
@@ -24,6 +25,8 @@ interface PrimaryDoctorRepository {
     fun delete(primaryDoctor: PrimaryDoctor)
 
     fun deleteByUser(user: User)
+
+    fun deleteByDoctor(doctor: Doctor)
 }
 
 @Repository
@@ -173,6 +176,23 @@ class PrimaryDoctorRepositoryImpl(
         val sqlParams =
             MapSqlParameterSource()
                 .addValue("userID", user.userID.value)
+
+        namedParameterJdbcTemplate.update(sql, sqlParams)
+    }
+
+    override fun deleteByDoctor(doctor: Doctor) {
+        // language=postgresql
+        val sql =
+            """
+            UPDATE primary_doctors
+            SET deleted_at = NOW()
+            WHERE doctor_id = :doctorID
+            AND deleted_at IS NULL
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("doctorID", doctor.doctorID.value)
 
         namedParameterJdbcTemplate.update(sql, sqlParams)
     }

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallDeleteByDoctorIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/call/CallDeleteByDoctorIDTest.kt
@@ -1,0 +1,67 @@
+package com.unicorn.api.controller.call
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@Sql("/db/primary_doctor/Insert_Parent_Account_Data.sql")
+@Sql("/db/primary_doctor/Insert_User_Data.sql")
+@Sql("/db/primary_doctor/Insert_Hospital_Data.sql")
+@Sql("/db/primary_doctor/Insert_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Department_Data.sql")
+@Sql("/db/call_support/Insert_Call_Support_Data.sql")
+@Sql("/db/call/Insert_New_Call_Data.sql")
+class CallDeleteByDoctorIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when call reservation is deleted`() {
+        val doctorID = "doctor"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/calls")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", doctorID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when doctor not found`() {
+        val doctorID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/calls")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", doctorID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/chat/ChatDeleteByDoctorIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/chat/ChatDeleteByDoctorIDTest.kt
@@ -1,0 +1,57 @@
+package com.unicorn.api.controller.chat
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@AutoConfigureMockMvc
+@Sql("/db/account/Insert_Account_Data.sql")
+@Sql("/db/hospital/Insert_Hospital_Data.sql")
+@Sql("/db/department/Insert_Department_Data.sql")
+@Sql("/db/doctor/Insert_Doctor_Data.sql")
+@Sql("/db/doctor_department/Insert_Doctor_Department_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/chat/Insert_Chat_Data.sql")
+@Sql("/db/message/Insert_Message_Data.sql")
+class ChatDeleteByDoctorIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete chat`() {
+        val doctorID = "doctor"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/chats")
+                    .header("X-UID", doctorID),
+            )
+
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when delete chat with invalid doctorID`() {
+        val doctorID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/chats")
+                    .header("X-UID", doctorID),
+            )
+
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DeleteDoctorDepartmentsTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/departments/DeleteDoctorDepartmentsTest.kt
@@ -1,0 +1,66 @@
+package com.unicorn.api.controller.departments
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/primary_doctor/Insert_Parent_Account_Data.sql")
+@Sql("/db/primary_doctor/Insert_User_Data.sql")
+@Sql("/db/primary_doctor/Insert_Hospital_Data.sql")
+@Sql("/db/primary_doctor/Insert_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_PrimaryDoctor_Data.sql")
+class DeleteDoctorDepartmentsTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete doctor departments`() {
+        val doctorID = "doctor"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/doctor_departments")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", doctorID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when doctor not found`() {
+        val doctorID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/doctor_departments")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", doctorID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/message/MessageDeleteByDoctorIDTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/message/MessageDeleteByDoctorIDTest.kt
@@ -1,0 +1,57 @@
+package com.unicorn.api.controller.message
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@AutoConfigureMockMvc
+@Sql("/db/account/Insert_Account_Data.sql")
+@Sql("/db/hospital/Insert_Hospital_Data.sql")
+@Sql("/db/department/Insert_Department_Data.sql")
+@Sql("/db/doctor/Insert_Doctor_Data.sql")
+@Sql("/db/doctor_department/Insert_Doctor_Department_Data.sql")
+@Sql("/db/user/Insert_User_Data.sql")
+@Sql("/db/chat/Insert_Chat_Data.sql")
+@Sql("/db/message/Insert_Message_Data.sql")
+class MessageDeleteByDoctorIDTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete message`() {
+        val doctorID = "doctor"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/messages")
+                    .header("X-UID", doctorID),
+            )
+
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when delete message with invalid doctorID`() {
+        val doctorID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/messages")
+                    .header("X-UID", doctorID),
+            )
+
+        result.andExpect(status().isBadRequest)
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorDeleteByDoctorTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/controller/primary_doctor/PrimaryDoctorDeleteByDoctorTest.kt
@@ -1,0 +1,79 @@
+package com.unicorn.api.controller.primary_doctor
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureMockMvc
+@Transactional
+@Sql("/db/primary_doctor/Insert_Parent_Account_Data.sql")
+@Sql("/db/primary_doctor/Insert_User_Data.sql")
+@Sql("/db/primary_doctor/Insert_Hospital_Data.sql")
+@Sql("/db/primary_doctor/Insert_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Data.sql")
+@Sql("/db/primary_doctor/Insert_Doctor_Department_Data.sql")
+@Sql("/db/primary_doctor/Insert_PrimaryDoctor_Data.sql")
+class PrimaryDoctorDeleteByDoctorTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return 204 when delete primary doctor`() {
+        val doctorID = "doctor"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/primary_doctors")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", doctorID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should return 400 when doctor not found`() {
+        val doctorID = "not_found"
+
+        val result =
+            mockMvc.perform(
+                MockMvcRequestBuilders.delete("/doctors/$doctorID/primary_doctors")
+                    .headers(
+                        HttpHeaders().apply {
+                            add("X-UID", doctorID)
+                        },
+                    )
+                    .contentType(MediaType.APPLICATION_JSON),
+            )
+        result.andExpect(status().isBadRequest)
+        result.andExpect(
+            content().json(
+                // language=json
+                """
+                {
+                    "errorType": "Doctor not found"
+                }
+                """.trimIndent(),
+                true,
+            ),
+        )
+    }
+}

--- a/api-server/src/test/kotlin/com/unicorn/api/infrastructure/message/MessageRepositoryTest.kt
+++ b/api-server/src/test/kotlin/com/unicorn/api/infrastructure/message/MessageRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.unicorn.api.infrastructure.message
 
+import com.unicorn.api.domain.doctor.Doctor
+import com.unicorn.api.domain.doctor.DoctorID
 import com.unicorn.api.domain.message.Message
 import com.unicorn.api.domain.message.MessageID
 import com.unicorn.api.domain.user.User
@@ -100,6 +102,36 @@ class MessageRepositoryTest {
         }
     }
 
+    private fun findByDoctorID(doctorID: DoctorID): List<Message> {
+        // language=postgresql
+        val sql =
+            """
+            SELECT
+                message_id,
+                chat_id,
+                sender_id,
+                sent_at,
+                content
+            FROM messages
+            WHERE sender_id = :doctorID
+            AND deleted_at IS NULL
+            """.trimIndent()
+
+        val sqlParams =
+            MapSqlParameterSource()
+                .addValue("doctorID", doctorID.value)
+
+        return namedParameterJdbcTemplate.query(sql, sqlParams) { rs, _ ->
+            Message.fromStore(
+                messageID = UUID.fromString(rs.getString("message_id")),
+                chatID = UUID.fromString(rs.getString("chat_id")),
+                senderID = rs.getString("sender_id"),
+                sentAt = rs.getObject("sent_at", OffsetDateTime::class.java),
+                content = rs.getString("content"),
+            )
+        }
+    }
+
     @Test
     fun `should store message`() {
         val chatID = UUID.fromString("e38fd3d0-99bc-11ef-8e52-cfa170f7b603")
@@ -187,6 +219,26 @@ class MessageRepositoryTest {
         messageRepository.deleteByUser(user)
 
         val deletedMessage = findByUserID(UserID(user.userID.value))
+        assertEquals(0, deletedMessage.size)
+    }
+
+    @Test
+    fun `should delete message by doctor`() {
+        val doctor =
+            Doctor.fromStore(
+                doctorID = "doctor",
+                hospitalID = UUID.fromString("d8bfa31d-54b9-4c64-a499-6c522517e5f7"),
+                firstName = "test",
+                lastName = "test",
+                email = "test@test.com",
+                phoneNumber = "1234567890",
+                doctorIconUrl = "https://example.com",
+                departments = listOf(UUID.fromString("b68a87a3-b7f1-4b85-b0ab-6c620d68d791")),
+            )
+
+        messageRepository.deleteByDoctor(doctor)
+
+        val deletedMessage = findByDoctorID(doctor.doctorID)
         assertEquals(0, deletedMessage.size)
     }
 }


### PR DESCRIPTION
## 概要
doctorID を使用した 削除機能の実装

## 変更点

- chats 削除機能の実装
- messages 削除機能の実装
- call_reservations 削除機能の実装
- primary_doctors 削除機能の実装
- doctor_departments 削除機能の実装

## 確認したこと
- テストが通ること

## リリース時に確認すること
- Doctor の削除前に各 API をたたいてください。Doctor 削除後はエラーになります。
